### PR TITLE
Added Bot Prefix Command Call

### DIFF
--- a/Floofbot/Handlers/CommandHandler.cs
+++ b/Floofbot/Handlers/CommandHandler.cs
@@ -59,7 +59,7 @@ namespace Floofbot.Handlers
                 prefix = BotConfigFactory.Config.Prefix;
             }
 
-            if (msg.HasStringPrefix(prefix, ref argPos))
+            if (msg.HasStringPrefix(prefix, ref argPos) || msg.HasMentionPrefix(_client.CurrentUser, ref argPos))
             {
                 var result = await _commands.ExecuteAsync(context, argPos, _services);
 


### PR DESCRIPTION
This will allow users to mention the bot to use command eg "@FloofBot ping"

Useful if two bots have the same prefix or users are unsure what the prefix is/dont want to use it