### PR TITLE
Added being able to search warnlogs of users not in server

### DIFF
--- a/Floofbot/Modules/Administration.cs
+++ b/Floofbot/Modules/Administration.cs
@@ -7,7 +7,6 @@ using System;
 using System.Linq;
 using System.Threading.Tasks;
 using System.Text.RegularExpressions;
-using System.Reflection.Metadata.Ecma335;
 
 namespace Floofbot.Modules
 {


### PR DESCRIPTION
Mods can now search the warning history of users not in the server by supplying their user ID. The system will check the database for that user ID