### PR TITLE
Added an Auto Ban On User Join

### DIFF
--- a/Floofbot/Migrations/20200707170117_BanOnJoin.Designer.cs
+++ b/Floofbot/Migrations/20200707170117_BanOnJoin.Designer.cs
@@ -3,14 +3,16 @@ using System;
 using Floofbot.Services.Repository;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace Floofbot.Migrations
 {
     [DbContext(typeof(FloofDataContext))]
-    partial class FloofDataContextModelSnapshot : ModelSnapshot
+    [Migration("20200707170117_BanOnJoin")]
+    partial class BanOnJoin
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Floofbot/Migrations/20200707170117_BanOnJoin.cs
+++ b/Floofbot/Migrations/20200707170117_BanOnJoin.cs
@@ -1,0 +1,32 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace Floofbot.Migrations
+{
+    public partial class BanOnJoin : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "BansOnJoin",
+                columns: table => new
+                {
+                    Id = table.Column<int>(nullable: false)
+                        .Annotation("Sqlite:Autoincrement", true),
+                    UserID = table.Column<ulong>(nullable: false),
+                    ModID = table.Column<ulong>(nullable: false),
+                    ModUsername = table.Column<string>(nullable: true),
+                    Reason = table.Column<string>(nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_BansOnJoin", x => x.Id);
+                });
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "BansOnJoin");
+        }
+    }
+}

--- a/Floofbot/Services/Repository/FloofDataContext.cs
+++ b/Floofbot/Services/Repository/FloofDataContext.cs
@@ -25,6 +25,7 @@ namespace Floofbot.Services.Repository
         public virtual DbSet<UserAssignableRole> UserAssignableRoles { get; set; }
         public virtual DbSet<TagConfig> TagConfigs { get; set; }
         public virtual DbSet<UserNote> UserNotes { get; set; }
+        public virtual DbSet<BanOnJoin> BansOnJoin { get; set; }
 
         protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
         {

--- a/Floofbot/Services/Repository/Models/BanOnJoin.cs
+++ b/Floofbot/Services/Repository/Models/BanOnJoin.cs
@@ -1,0 +1,18 @@
+﻿using Microsoft.AspNetCore.SignalR;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Text;
+
+namespace Floofbot.Services.Repository.Models
+{
+    public partial class BanOnJoin
+    {
+        [Key]
+        public int Id { get; set; }
+        public ulong UserID { get; set; }
+        public ulong ModID { get; set; }
+        public string ModUsername { get; set; }
+        public string Reason { get; set; }
+    }
+}


### PR DESCRIPTION
Sometimes when a user leaves before the mods can ban them, the api is unable to find the user. This feature allows the mods to provide a user ID that will be added to the database and banned whenever they rejoin the server