### PR TITLE
Updated warnlog to have clickable hyperlink to warning

### DIFF
--- a/Floofbot/Floofbot.csproj
+++ b/Floofbot/Floofbot.csproj
@@ -25,11 +25,6 @@
     <ConfigFiles Include="*.config" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Compile Remove="Migrations\20200708223314_WarnLogUpat.cs" />
-    <Compile Remove="Migrations\20200708223314_WarnLogUpat.Designer.cs" />
-  </ItemGroup>
-
   <Target Name="CopyConfigs" AfterTargets="AfterBuild">
     <Copy SourceFiles="@(ConfigFiles)" DestinationFolder="$(OutDir)" SkipUnchangedFiles="true" />
   </Target>

--- a/Floofbot/Floofbot.csproj
+++ b/Floofbot/Floofbot.csproj
@@ -25,6 +25,11 @@
     <ConfigFiles Include="*.config" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Compile Remove="Migrations\20200708223314_WarnLogUpat.cs" />
+    <Compile Remove="Migrations\20200708223314_WarnLogUpat.Designer.cs" />
+  </ItemGroup>
+
   <Target Name="CopyConfigs" AfterTargets="AfterBuild">
     <Copy SourceFiles="@(ConfigFiles)" DestinationFolder="$(OutDir)" SkipUnchangedFiles="true" />
   </Target>

--- a/Floofbot/Migrations/20200708223402_WarnLogUpdate.Designer.cs
+++ b/Floofbot/Migrations/20200708223402_WarnLogUpdate.Designer.cs
@@ -3,14 +3,16 @@ using System;
 using Floofbot.Services.Repository;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace Floofbot.Migrations
 {
     [DbContext(typeof(FloofDataContext))]
-    partial class FloofDataContextModelSnapshot : ModelSnapshot
+    [Migration("20200708223402_WarnLogUpdate")]
+    partial class WarnLogUpdate
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Floofbot/Migrations/20200708223402_WarnLogUpdate.cs
+++ b/Floofbot/Migrations/20200708223402_WarnLogUpdate.cs
@@ -1,0 +1,22 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace Floofbot.Migrations
+{
+    public partial class WarnLogUpdate : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "warningUrl",
+                table: "Warnings",
+                nullable: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "warningUrl",
+                table: "Warnings");
+        }
+    }
+}

--- a/Floofbot/Modules/Administration.cs
+++ b/Floofbot/Modules/Administration.cs
@@ -815,7 +815,7 @@ namespace Floofbot.Modules
             bool oldStatus = (function == "forgiven") ? false : true; // if we are forgiving them then their old status must be unforgiven
             if (string.IsNullOrEmpty(type) || string.IsNullOrEmpty(badUser) || (!type.ToLower().Equals("warning") && !type.ToLower().Equals("usernote"))) // invalid parameters
             {
-                Embed embed = CreateDescriptionEmbed($"💾 Usage: `{function} [warning/usernote] [user]`");
+                Embed embed = CreateDescriptionEmbed($"💾 Usage: `{(function == "forgiven" ? "forgive" : "unforgive")} [warning/usernote] [user]`");
                 await SendEmbed(embed);
                 return;
             }

--- a/Floofbot/Modules/Administration.cs
+++ b/Floofbot/Modules/Administration.cs
@@ -482,19 +482,19 @@ namespace Floofbot.Modules
                 builder.AddField(":warning: | Formal Warnings:", "\\_\\_\\_\\_\\_\\_\\_\\_\\_\\_\\_\\_\\_\\_\\_\\_\\_\\_\\_\\_\\_");
                 foreach (Warning warning in formalWarnings)
                 {
-                    var HyperLink = "";
+                    var hyperLink = "";
                     if (warning.warningUrl != null && Uri.IsWellFormedUriString(warning.warningUrl, UriKind.Absolute)) // make sure url is good
-                        HyperLink = $"[Jump To Warning]({warning.warningUrl})\n";
+                        hyperLink = $"[Jump To Warning]({warning.warningUrl})\n";
 
                     if (warning.Forgiven)
                     {
                         IUser forgivenBy = resolveUser(warning.ForgivenBy.ToString());
                         var forgivenByText = (forgivenBy == null) ? "" : $"(forgiven by {forgivenBy.Username}#{forgivenBy.Discriminator})";
-                        builder.AddField($"~~**{warningCount + 1}**. {warning.DateAdded.ToString("yyyy MMMM dd")} - {warning.Moderator}~~ {forgivenByText}", $"{HyperLink}```{warning.Reason}```");
+                        builder.AddField($"~~**{warningCount + 1}**. {warning.DateAdded.ToString("yyyy MMMM dd")} - {warning.Moderator}~~ {forgivenByText}", $"{hyperLink}```{warning.Reason}```");
                     }
                     else
                     {
-                        builder.AddField($"**{warningCount + 1}**. {warning.DateAdded.ToString("yyyy MMMM dd")} - {warning.Moderator}", $"{HyperLink}```{warning.Reason}```");
+                        builder.AddField($"**{warningCount + 1}**. {warning.DateAdded.ToString("yyyy MMMM dd")} - {warning.Moderator}", $"{hyperLink}```{warning.Reason}```");
                     }
                     warningCount++;
                 }

--- a/Floofbot/Services/Repository/Models/Warning.cs
+++ b/Floofbot/Services/Repository/Models/Warning.cs
@@ -15,5 +15,6 @@ namespace Floofbot.Services.Repository.Models
         public string Moderator { get; set; }
         public string Reason { get; set; }
         public ulong UserId { get; set; }
+        public string warningUrl { get; set; }
     }
 }


### PR DESCRIPTION
A clickable hyperlink has been added which links to the original warning message. This allows moderators to jump to when the user was warned to get context about the warning