### PR TITLE
Added Basic Raid Protection Service and Commands

### DIFF
--- a/Floofbot/Migrations/20200822094523_RaidProtection.Designer.cs
+++ b/Floofbot/Migrations/20200822094523_RaidProtection.Designer.cs
@@ -3,14 +3,16 @@ using System;
 using Floofbot.Services.Repository;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace Floofbot.Migrations
 {
     [DbContext(typeof(FloofDataContext))]
-    partial class FloofDataContextModelSnapshot : ModelSnapshot
+    [Migration("20200822094523_RaidProtection")]
+    partial class RaidProtection
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Floofbot/Migrations/20200822094523_RaidProtection.cs
+++ b/Floofbot/Migrations/20200822094523_RaidProtection.cs
@@ -1,0 +1,33 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace Floofbot.Migrations
+{
+    public partial class RaidProtection : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "RaidProtectionConfigs",
+                columns: table => new
+                {
+                    ServerId = table.Column<ulong>(nullable: false),
+                    Enabled = table.Column<bool>(nullable: false),
+                    ModChannelId = table.Column<ulong>(nullable: true),
+                    ModRoleId = table.Column<ulong>(nullable: true),
+                    MutedRoleId = table.Column<ulong>(nullable: true),
+                    ExceptionRoleId = table.Column<ulong>(nullable: true),
+                    BanOffenders = table.Column<bool>(nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_RaidProtectionConfigs", x => x.ServerId);
+                });
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "RaidProtectionConfigs");
+        }
+    }
+}

--- a/Floofbot/Modules/RaidProtectionCommands.cs
+++ b/Floofbot/Modules/RaidProtectionCommands.cs
@@ -56,16 +56,11 @@ namespace Floofbot.Modules
         private async Task<SocketRole> resolveRole(string input, SocketGuild guild, ISocketMessageChannel channel)
         {
             SocketRole role = null;
-            bool roleFound = false;
             //resolve roleID or @mention
             if (Regex.IsMatch(input, @"\d{10,}"))
             {
                 string roleID = Regex.Match(input, @"\d{10,}").Value;
                 role = guild.GetRole(Convert.ToUInt64(roleID));
-                if (role != null)
-                    roleFound = true;
-                else
-                    roleFound = false;
             }
             //resolve role name
             else
@@ -74,9 +69,8 @@ namespace Floofbot.Modules
                 {
                     if (r.Name.ToLower() == input.ToLower())
                     {
-                        if (roleFound == false) // ok we found 1 role thats GOOD
+                        if (role == null) // ok we found 1 role thats GOOD
                         {
-                            roleFound = true;
                             role = r;
                         }
                         else // there is more than 1 role with the same name!

--- a/Floofbot/Modules/RaidProtectionCommands.cs
+++ b/Floofbot/Modules/RaidProtectionCommands.cs
@@ -87,14 +87,7 @@ namespace Floofbot.Modules
                     }
                 }
             }
-            if (roleFound)
-            {
-                return role;
-            }
-            else
-            {
-                return null;
-            }
+             return role;
         }
         [Command("modchannel")]
         [Summary("OPTIONAL: Sets the mod channel for raid notifications")]

--- a/Floofbot/Modules/RaidProtectionCommands.cs
+++ b/Floofbot/Modules/RaidProtectionCommands.cs
@@ -100,7 +100,7 @@ namespace Floofbot.Modules
                 var ServerConfig = GetServerConfig(Context.Guild.Id);
                 ServerConfig.BanOffenders = !ServerConfig.BanOffenders;
                 _floofDB.SaveChanges();
-                await Context.Channel.SendMessageAsync("Raid Protection Bans " + (ServerConfig.Enabled ? "Enabled!" : "Disabled!"));
+                await Context.Channel.SendMessageAsync("Raid Protection Bans " + (ServerConfig.BanOffenders ? "Enabled!" : "Disabled!"));
             }
             catch (Exception ex)
             {
@@ -193,7 +193,7 @@ namespace Floofbot.Modules
 
                 if (mutedRoleFound)
                 {
-                    ServerConfig.ModRoleId = roleId;
+                    ServerConfig.MutedRoleId = roleId;
                     _floofDB.SaveChanges();
                     await Context.Channel.SendMessageAsync("Muted role set!");
                 }
@@ -243,7 +243,7 @@ namespace Floofbot.Modules
 
                 if (exceptionsRoleFound)
                 {
-                    ServerConfig.ModRoleId = roleId;
+                    ServerConfig.ExceptionRoleId = roleId;
                     _floofDB.SaveChanges();
                     await Context.Channel.SendMessageAsync("Exceptions role set!");
                 }

--- a/Floofbot/Modules/RaidProtectionCommands.cs
+++ b/Floofbot/Modules/RaidProtectionCommands.cs
@@ -165,17 +165,17 @@ namespace Floofbot.Modules
             var ServerConfig = GetServerConfig(Context.Guild.Id);
             var foundRole = await resolveRole(role, Context.Guild, Context.Channel);
 
-                if (foundRole != null)
-                {
-                    ServerConfig.ModRoleId = foundRole.Id;
-                    _floofDB.SaveChanges();
-                    await Context.Channel.SendMessageAsync("Mod role set to " + foundRole.Name + "!");
-                }
-                else
-                {
-                    await Context.Channel.SendMessageAsync("Unable to set that role.");
-                    return;
-                }
+            if (foundRole != null)
+            {
+                ServerConfig.ModRoleId = foundRole.Id;
+                _floofDB.SaveChanges();
+                await Context.Channel.SendMessageAsync("Mod role set to " + foundRole.Name + "!");
+            }
+            else
+            {
+                await Context.Channel.SendMessageAsync("Unable to set that role.");
+                return;
+            }
         }
         [Command("mutedrole")]
         [Summary("OPTIONAL: A role to give to users to mute them in the server. If not set, users are banned by default.")]

--- a/Floofbot/Modules/RaidProtectionCommands.cs
+++ b/Floofbot/Modules/RaidProtectionCommands.cs
@@ -1,0 +1,263 @@
+﻿using Discord;
+using Discord.Addons.Interactive;
+using Discord.Commands;
+using Discord.WebSocket;
+using Floofbot.Services.Repository;
+using Floofbot.Services.Repository.Models;
+using Serilog;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Floofbot.Modules
+{
+    [Summary("Raid protection configuration commands")]
+    [RequireUserPermission(GuildPermission.Administrator)]
+    [Group("raidconfig")]
+    public class RaidProtectionCommands : InteractiveBase
+    {
+        private FloofDataContext _floofDB;
+
+        public RaidProtectionCommands(FloofDataContext floofDB)
+        {
+            _floofDB = floofDB;
+        }
+        private Discord.Color GenerateColor()
+        {
+            return new Discord.Color((uint)new Random().Next(0x1000000));
+        }
+
+        private RaidProtectionConfig GetServerConfig(ulong server)
+        {
+            // checks if server exists in database and adds if not
+            var serverConfig = _floofDB.RaidProtectionConfigs.Find(server);
+            if (serverConfig == null)
+            {
+                _floofDB.Add(new RaidProtectionConfig
+                {
+                    ServerId = server,
+                    Enabled = false,
+                    ModChannelId = null,
+                    ModRoleId = null,
+                    MutedRoleId = null,
+                    BanOffenders = true,
+                    ExceptionRoleId = null
+                });
+                _floofDB.SaveChanges();
+                return _floofDB.RaidProtectionConfigs.Find(server);
+            }
+            else
+            {
+                return serverConfig;
+            }
+        }
+
+        [Command("modchannel")]
+        [Summary("OPTIONAL: Sets the mod channel for raid notifications")]
+        public async Task ModChannel([Summary("Channel (eg #alerts)")]Discord.IChannel channel = null)
+        {
+            if (channel == null)
+            {
+                channel = Context.Channel;
+            }
+            var ServerConfig = GetServerConfig(Context.Guild.Id);
+            ServerConfig.ModChannelId = channel.Id;
+            _floofDB.SaveChanges();
+            await Context.Channel.SendMessageAsync("Channel updated! I will raid notifications to <#" + channel.Id + ">");
+        }
+
+        [Command("toggle")]
+        [Summary("Toggles the raid protection")]
+        public async Task Toggle()
+        {
+
+            // try toggling
+            try
+            {
+                // check the status of raid protection
+                var ServerConfig = GetServerConfig(Context.Guild.Id);
+                ServerConfig.Enabled = !ServerConfig.Enabled;
+                _floofDB.SaveChanges();
+                await Context.Channel.SendMessageAsync("Raid Protection " + (ServerConfig.Enabled ? "Enabled!" : "Disabled!"));
+            }
+            catch (Exception ex)
+            {
+                await Context.Channel.SendMessageAsync("An error occured: " + ex.Message);
+                Log.Error("Error when trying to toggle raid protection: " + ex);
+                return;
+            }
+        }
+        [Command("togglebans")]
+        [Summary("Toggles whether to ban or mute users that trigger the raid detection.")]
+        public async Task ToggleBans()
+        {
+
+            // try toggling
+            try
+            {
+                // check the status of raid protection
+                var ServerConfig = GetServerConfig(Context.Guild.Id);
+                ServerConfig.BanOffenders = !ServerConfig.BanOffenders;
+                _floofDB.SaveChanges();
+                await Context.Channel.SendMessageAsync("Raid Protection Bans " + (ServerConfig.Enabled ? "Enabled!" : "Disabled!"));
+            }
+            catch (Exception ex)
+            {
+                await Context.Channel.SendMessageAsync("An error occured: " + ex.Message);
+                Log.Error("Error when trying to toggle raid protection banning: " + ex);
+                return;
+            }
+        }
+        [Command("modrole")]
+        [Summary("OPTIONAL: A role to ping for raid alerts.")]
+        public async Task SetModRole(string roleName = null)
+        {
+            if (roleName == null)
+            {
+                await Context.Channel.SendMessageAsync("", false, new EmbedBuilder { Description = $"💾 Usage: `raidconfig modrole [rolename]`", Color = GenerateColor() }.Build());
+                return;
+            }
+
+            var ServerConfig = GetServerConfig(Context.Guild.Id);
+            bool modRoleFound = false;
+            ulong? roleId = null;
+            try
+            {
+                foreach (SocketRole r in Context.Guild.Roles)
+                {
+                    if (r.Name.ToLower() == roleName.ToLower())
+                    {
+                        if (modRoleFound == false) // ok we found 1 role thats GOOD
+                        {
+                            modRoleFound = true;
+                            roleId = r.Id;
+                        }
+                        else // there is more than 1 role with the same name!
+                        {
+                            await Context.Channel.SendMessageAsync("More than one role exists with that name! Not sure what to do! Please resolve this. Aborting..");
+                            return;
+                        }
+                    }
+                }
+
+                if (modRoleFound)
+                {
+                    ServerConfig.ModRoleId = roleId;
+                    _floofDB.SaveChanges();
+                    await Context.Channel.SendMessageAsync("Mod role set!");
+                }
+                else
+                {
+                    await Context.Channel.SendMessageAsync("Unable to find that role. Role not set.");
+                    return;
+                }
+            }
+            catch (Exception ex)
+            {
+                await Context.Channel.SendMessageAsync("An error occured: " + ex.Message);
+                Log.Error("Error when trying to set the raid protection mod role: " + ex);
+            }
+        }
+        [Command("mutedrole")]
+        [Summary("OPTIONAL: A role to give to users to mute them in the server. If not set, users are banned by default.")]
+        public async Task SetMutedRole(string roleName = null)
+        {
+            if (roleName == null)
+            {
+                await Context.Channel.SendMessageAsync("", false, new EmbedBuilder { Description = $"💾 Usage: `raidconfig mutedrole [rolename]`", Color = GenerateColor() }.Build());
+                return;
+            }
+
+            var ServerConfig = GetServerConfig(Context.Guild.Id);
+            bool mutedRoleFound = false;
+            ulong? roleId = null;
+            try
+            {
+                foreach (SocketRole r in Context.Guild.Roles)
+                {
+                    if (r.Name.ToLower() == roleName.ToLower())
+                    {
+                        if (mutedRoleFound == false) // ok we found 1 role thats GOOD
+                        {
+                            mutedRoleFound = true;
+                            roleId = r.Id;
+                        }
+                        else // there is more than 1 role with the same name!
+                        {
+                            await Context.Channel.SendMessageAsync("More than one role exists with that name! Not sure what to do! Please resolve this. Aborting..");
+                            return;
+                        }
+                    }
+                }
+
+                if (mutedRoleFound)
+                {
+                    ServerConfig.ModRoleId = roleId;
+                    _floofDB.SaveChanges();
+                    await Context.Channel.SendMessageAsync("Muted role set!");
+                }
+                else
+                {
+                    await Context.Channel.SendMessageAsync("Unable to find that role. Role not set.");
+                    return;
+                }
+            }
+            catch (Exception ex)
+            {
+                await Context.Channel.SendMessageAsync("An error occured: " + ex.Message);
+                Log.Error("Error when trying to set the raid protection muted role: " + ex);
+            }
+        }
+        [Command("exceptionsrole")]
+        [Summary("OPTIONAL: Users with this role are immune to raid protection.")]
+        public async Task SetExceptionsRole(string roleName = null)
+        {
+            if (roleName == null)
+            {
+                await Context.Channel.SendMessageAsync("", false, new EmbedBuilder { Description = $"💾 Usage: `raidconfig exceptionsrole [rolename]`", Color = GenerateColor() }.Build());
+                return;
+            }
+
+            var ServerConfig = GetServerConfig(Context.Guild.Id);
+            bool exceptionsRoleFound = false;
+            ulong? roleId = null;
+            try
+            {
+                foreach (SocketRole r in Context.Guild.Roles)
+                {
+                    if (r.Name.ToLower() == roleName.ToLower())
+                    {
+                        if (exceptionsRoleFound == false) // ok we found 1 role thats GOOD
+                        {
+                            exceptionsRoleFound = true;
+                            roleId = r.Id;
+                        }
+                        else // there is more than 1 role with the same name!
+                        {
+                            await Context.Channel.SendMessageAsync("More than one role exists with that name! Not sure what to do! Please resolve this. Aborting..");
+                            return;
+                        }
+                    }
+                }
+
+                if (exceptionsRoleFound)
+                {
+                    ServerConfig.ModRoleId = roleId;
+                    _floofDB.SaveChanges();
+                    await Context.Channel.SendMessageAsync("Exceptions role set!");
+                }
+                else
+                {
+                    await Context.Channel.SendMessageAsync("Unable to find that role. Role not set.");
+                    return;
+                }
+            }
+            catch (Exception ex)
+            {
+                await Context.Channel.SendMessageAsync("An error occured: " + ex.Message);
+                Log.Error("Error when trying to set the raid protection exceptions role: " + ex);
+            }
+        }
+    }
+}

--- a/Floofbot/Modules/RaidProtectionCommands.cs
+++ b/Floofbot/Modules/RaidProtectionCommands.cs
@@ -132,13 +132,16 @@ namespace Floofbot.Modules
         [Summary("OPTIONAL: A role to ping for raid alerts.")]
         public async Task SetModRole(string role = null)
         {
+            var ServerConfig = GetServerConfig(Context.Guild.Id);
+
             if (role == null)
             {
-                await Context.Channel.SendMessageAsync("", false, new EmbedBuilder { Description = $"💾 Usage: `raidconfig modrole [rolename]`", Color = GenerateColor() }.Build());
+                ServerConfig.ModRoleId = null;
+                _floofDB.SaveChanges();
+                await Context.Channel.SendMessageAsync("Mod role removed. I will no longer ping a mod role.");
                 return;
             }
 
-            var ServerConfig = GetServerConfig(Context.Guild.Id);
             var foundRole = await resolveRole(role, Context.Guild, Context.Channel);
 
             if (foundRole != null)
@@ -157,13 +160,16 @@ namespace Floofbot.Modules
         [Summary("OPTIONAL: A role to give to users to mute them in the server. If not set, users are banned by default.")]
         public async Task SetMutedRole(string role = null)
         {
+            var ServerConfig = GetServerConfig(Context.Guild.Id);
+
             if (role == null)
             {
-                await Context.Channel.SendMessageAsync("", false, new EmbedBuilder { Description = $"💾 Usage: `raidconfig mutedrole [rolename]`", Color = GenerateColor() }.Build());
+                ServerConfig.MutedRoleId = null;
+                _floofDB.SaveChanges();
+                await Context.Channel.SendMessageAsync("Muted role removed. I will now default to banning users.");
                 return;
             }
 
-            var ServerConfig = GetServerConfig(Context.Guild.Id);
             var foundRole = await resolveRole(role, Context.Guild, Context.Channel);
 
             if (foundRole != null)
@@ -182,13 +188,16 @@ namespace Floofbot.Modules
         [Summary("OPTIONAL: Users with this role are immune to raid protection.")]
         public async Task SetExceptionsRole(string role = null)
         {
+            var ServerConfig = GetServerConfig(Context.Guild.Id);
+
             if (role == null)
             {
-                await Context.Channel.SendMessageAsync("", false, new EmbedBuilder { Description = $"💾 Usage: `raidconfig exceptionsrole [rolename]`", Color = GenerateColor() }.Build());
+                ServerConfig.ExceptionRoleId = null;
+                _floofDB.SaveChanges();
+                await Context.Channel.SendMessageAsync("Exceptions role removed. Users will no longer be exempt from raid protection.");
                 return;
             }
 
-            var ServerConfig = GetServerConfig(Context.Guild.Id);
             var foundRole = await resolveRole(role, Context.Guild, Context.Channel);
 
             if (foundRole != null)

--- a/Floofbot/Modules/RaidProtectionCommands.cs
+++ b/Floofbot/Modules/RaidProtectionCommands.cs
@@ -107,22 +107,11 @@ namespace Floofbot.Modules
         [Summary("Toggles the raid protection")]
         public async Task Toggle()
         {
-
-            // try toggling
-            try
-            {
-                // check the status of raid protection
-                var ServerConfig = GetServerConfig(Context.Guild.Id);
-                ServerConfig.Enabled = !ServerConfig.Enabled;
-                _floofDB.SaveChanges();
-                await Context.Channel.SendMessageAsync("Raid Protection " + (ServerConfig.Enabled ? "Enabled!" : "Disabled!"));
-            }
-            catch (Exception ex)
-            {
-                await Context.Channel.SendMessageAsync("An error occured: " + ex.Message);
-                Log.Error("Error when trying to toggle raid protection: " + ex);
-                return;
-            }
+            // check the status of raid protection
+            var ServerConfig = GetServerConfig(Context.Guild.Id);
+            ServerConfig.Enabled = !ServerConfig.Enabled;
+            _floofDB.SaveChanges();
+            await Context.Channel.SendMessageAsync("Raid Protection " + (ServerConfig.Enabled ? "Enabled!" : "Disabled!"));
         }
         [Command("togglebans")]
         [Summary("Toggles whether to ban or mute users that trigger the raid detection.")]

--- a/Floofbot/Services/EventLoggerService.cs
+++ b/Floofbot/Services/EventLoggerService.cs
@@ -177,6 +177,17 @@ namespace Floofbot.Services
                     if (messageBefore.Content == after.Content) // no change
                         return;
 
+                    bool messageTriggeredRaidProtection = _raidProtectionService.CheckMessage(new FloofDataContext(), after).Result;
+                    if (messageTriggeredRaidProtection)
+                    {
+                        await after.DeleteAsync();
+                        return;
+                    }
+
+                    bool hasBadWord = _wordFilterService.hasFilteredWord(new FloofDataContext(), after.Content, channel.Guild.Id, after.Channel.Id);
+                    if (hasBadWord)
+                        await HandleBadMessage(after.Author, after);
+
                     if ((IsToggled(channel.Guild)) == false) // not toggled on
                         return;
 
@@ -198,10 +209,6 @@ namespace Floofbot.Services
                         embed.WithThumbnailUrl(after.Author.GetAvatarUrl());
 
                     await logChannel.SendMessageAsync("", false, embed.Build());
-
-                    bool hasBadWord = _wordFilterService.hasFilteredWord(new FloofDataContext(), after.Content, channel.Guild.Id, channel.Id);
-                    if (hasBadWord)
-                        await HandleBadMessage(after.Author, after);
                 }
                 catch (Exception ex)
                 {

--- a/Floofbot/Services/EventLoggerService.cs
+++ b/Floofbot/Services/EventLoggerService.cs
@@ -390,6 +390,8 @@ namespace Floofbot.Services
                     if (user.IsBot)
                         return;
 
+                    await _raidProtectionService.CheckForExcessiveJoins(user.Guild);
+
                     if ((IsToggled(user.Guild)) == false)
                         return;
 

--- a/Floofbot/Services/EventLoggerService.cs
+++ b/Floofbot/Services/EventLoggerService.cs
@@ -20,6 +20,7 @@ namespace Floofbot.Services
         private DiscordSocketClient _client;
         private WordFilterService _wordFilterService;
         private NicknameAlertService _nicknameAlertService;
+        private RaidProtectionService _raidProtectionService;
         private static readonly Color ADMIN_COLOR = Color.DarkOrange;
 
 
@@ -30,7 +31,7 @@ namespace Floofbot.Services
             // assisting handlers
             _wordFilterService = new WordFilterService();
             _nicknameAlertService = new NicknameAlertService(new FloofDataContext());
-
+            _raidProtectionService = new RaidProtectionService();
             // event handlers
             _client.MessageUpdated += MessageUpdated;
             _client.MessageDeleted += MessageDeleted;
@@ -115,6 +116,12 @@ namespace Floofbot.Services
                         return;
                     var channel = msg.Channel as ITextChannel;
                     string content = msg.Content;
+                    bool messageTriggeredRaidProtection = _raidProtectionService.CheckMessage(new FloofDataContext(), msg).Result;
+                    if (messageTriggeredRaidProtection)
+                    {
+                        await msg.DeleteAsync();
+                        return;
+                    }
                     bool hasBadWord = _wordFilterService.hasFilteredWord(new FloofDataContext(), msg.Content, channel.Guild.Id, msg.Channel.Id);
                     if (hasBadWord)
                         await HandleBadMessage(msg.Author, msg);

--- a/Floofbot/Services/RaidProtectionService.cs
+++ b/Floofbot/Services/RaidProtectionService.cs
@@ -323,10 +323,10 @@ namespace Floofbot.Services
                 if (exceptionsRole != null && guildUser != null)
                 {
                     foreach (IRole role in guildUser.Roles)
-                        {
+                    {
                         if (role.Id == exceptionsRole.Id)
                             return false;
-                        }
+                    }
                 }
             }
 

--- a/Floofbot/Services/RaidProtectionService.cs
+++ b/Floofbot/Services/RaidProtectionService.cs
@@ -1,0 +1,265 @@
+﻿using Discord;
+using Discord.WebSocket;
+using Floofbot.Services.Repository;
+using Floofbot.Services.Repository.Models;
+using Microsoft.AspNetCore.WebUtilities;
+using Serilog;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.NetworkInformation;
+using System.Security.Policy;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Threading.Channels;
+using System.Threading.Tasks;
+
+namespace Floofbot.Services
+{
+    public class RaidProtectionService
+    {
+        private DiscordSocketClient _client;
+        // will store user id and how many counts they've had
+        private Dictionary<ulong, int> userPunishmentCount = new Dictionary<ulong, int>();
+        // used to keep track of the number of messages a user sent for spam protection
+        private Dictionary<ulong, int> userMessageCount = new Dictionary<ulong, int>();
+        // determines how long before a user is forgiven for a punishment - currently 5 min
+        private static int forgivenDuration = 5 * 60;
+        // determines the rate at which users can send messages, currently no more than x messages in 5 seconds
+        private static int durationForMaxMessages = 3;
+        // determines the max number of punishments a user can have before being punished
+        private static int maxNumberOfPunishments = 3;
+
+
+
+        public RaidProtectionService(DiscordSocketClient client)
+        {
+            _client = client;
+            _client.MessageReceived += OnMessage;
+
+        }
+        public RaidProtectionConfig GetServerConfig(IGuild guild, FloofDataContext _floofDb)
+        {
+            RaidProtectionConfig serverConfig = _floofDb.RaidProtectionConfigs.Find(guild.Id);
+            return serverConfig;
+        }
+        public async Task<bool> CheckUserMessageCount(SocketMessage msg)
+        {
+            if (userMessageCount.ContainsKey(msg.Author.Id))
+            {
+                userMessageCount[msg.Author.Id] += 1;
+                if (userMessageCount[msg.Author.Id] >= 5) // no more than 5 messages in time frame
+                {
+                    await msg.Channel.SendMessageAsync(msg.Author.Mention + " you are sending messages too quickly!");
+                    // add a bad boye point for the user
+                    if (userPunishmentCount.ContainsKey(msg.Author.Id))
+                    {
+                        userPunishmentCount[msg.Author.Id] += 1;
+                    }
+                    else // they were a good boye but now they are not
+                    {
+                        userPunishmentCount.Add(msg.Author.Id, 1);
+                    }
+                    // we run an async task to remove their point after the specified duration
+                    await Task.Run(async () =>
+                    {
+                        await Task.Delay(forgivenDuration);
+
+                        userPunishmentCount[msg.Author.Id] -= 1;
+                    });
+                    return true;
+                }
+            }
+            else // they were a good boye but now they are not
+            {
+                userMessageCount.Add(msg.Author.Id, 1);
+            }
+            // we run an async task to remove their point after the specified duration
+            await Task.Run(async () => {
+                await Task.Delay(durationForMaxMessages);
+
+                userMessageCount[msg.Author.Id] -= 1;
+            });
+            return false;
+        }
+        public async Task CheckMentions(SocketUserMessage msg, IGuild guild)
+        {
+            if (msg.MentionedUsers.Count > 10)
+            {
+                string reason = "Raid Protection => " + msg.MentionedUsers.Count + " mentions in one message.";
+                try
+                {
+                    await guild.AddBanAsync(msg.Author, 1, reason);
+                }
+                catch (Exception e)
+                {
+                    Log.Error("Error banning user for mass mention: " + e);
+                }
+                await msg.DeleteAsync();
+                return;
+            }
+                
+        }
+        public async Task<bool> CheckLetterSpam(SocketMessage msg)
+        {
+            var matches = Regex.Matches(msg.Content, @"(.)\1+");
+            foreach (Match m in matches)
+            {
+                // string has more than 5 letters in a row
+                if (m.Length > 5)
+                {
+                    await msg.Channel.SendMessageAsync(msg.Author.Mention + " no spamming!");
+                    // add a bad boye point for the user
+                    if (userPunishmentCount.ContainsKey(msg.Author.Id))
+                    {
+                        userPunishmentCount[msg.Author.Id] += 1;
+                    }
+                    else // they were a good boye but now they are not
+                    {
+                        userPunishmentCount.Add(msg.Author.Id, 1);
+                    }
+                    // we run an async task to remove their point after the specified duration
+                    await Task.Run(async () => {
+                        await Task.Delay(forgivenDuration);
+
+                        userPunishmentCount[msg.Author.Id] -= 1;
+                    });
+                    // we return here because we only need to check for at least one match, doesnt matter if there are more
+                    return true;
+                }                     
+            }
+            return false;
+
+        }
+        public async Task<bool> CheckInviteLinks(SocketMessage msg)
+        {
+            if (msg.Content.Contains("http://discord.gg"))
+            {
+                await msg.Channel.SendMessageAsync(msg.Author.Mention + " no invite links!");
+                // add a bad boye point for the user
+                if (userPunishmentCount.ContainsKey(msg.Author.Id))
+                {
+                    userPunishmentCount[msg.Author.Id] += 1;
+                }
+                else // they were a good boye but now they are not
+                {
+                    userPunishmentCount.Add(msg.Author.Id, 1);
+                }
+                // we run an async task to remove their point after the specified duration
+                await Task.Run(async () => {
+                    await Task.Delay(forgivenDuration);
+
+                    userPunishmentCount[msg.Author.Id] -= 1;
+                });
+                // we return here because we only need to check for at least one match, doesnt matter if there are more
+                return true;
+            }
+            return false;
+        }
+        public Task OnMessage(SocketMessage msg)
+        {
+            var _ = Task.Run(async () =>
+            {
+                FloofDataContext floofDb = new FloofDataContext();
+                // can return null
+                var userMsg = msg as SocketUserMessage;
+                if (userMsg == null || msg.Author.IsBot)
+                    return;
+                // can return null
+                var channel = userMsg.Channel as ITextChannel;
+                if (channel == null)
+                    return;
+                // can return null
+                var guild = channel.Guild as SocketGuild;
+                if (guild == null)
+                    return;
+                var serverConfig = GetServerConfig(guild, floofDb);
+                // raid protection not configured
+                if (serverConfig == null)
+                    return;
+                // raid protection disabled
+                if (!serverConfig.Enabled)
+                    return;
+
+                // users with the exceptions role are immune to raid protection
+                if (serverConfig.ExceptionRoleId != null)
+                {
+                    // returns null if exception role doe not exist anymore
+                    var exceptionsRole = guild.GetRole((ulong)serverConfig.ExceptionRoleId); 
+                    var guildUser = guild.GetUser(msg.Author.Id);
+                    // role must exist and user must exist in server
+                    if (exceptionsRole != null && guildUser != null)
+                    {
+                        foreach (IRole role in guildUser.Roles)
+                            {
+                            if (role.Id == exceptionsRole.Id)
+                                return;
+                            }
+                    }
+                }
+
+                // get other values from db and get their associated roles and channels
+                var mutedRole = guild.GetRole((ulong)serverConfig.MutedRoleId);
+                var modRole = guild.GetRole((ulong)serverConfig.ModRoleId);
+                var modChannel = guild.GetChannel((ulong)serverConfig.ModChannelId) as ITextChannel;
+                var banOffenders = serverConfig.BanOffenders;
+
+                // now we run our checks. If any of them return true, we have a bad boy
+
+                // this will ALWAYS ban users regardless of muted role or not 
+                await CheckMentions(userMsg, guild);
+                // this will check their messages and see if they are spamming
+                bool userSpammedMessages = CheckUserMessageCount(msg).Result;
+                // this checks for spamming letters in a row
+                bool userSpammedLetters = CheckLetterSpam(msg).Result;
+                // this checks for posting invite links
+                bool userSpammedInviteLink = CheckInviteLinks(msg).Result;
+
+                if (userSpammedMessages || userSpammedLetters || userSpammedInviteLink)
+                {
+                    if (userPunishmentCount.ContainsKey(msg.Author.Id))
+                    {
+                        // they have been too much of a bad boye >:(
+                        if (userPunishmentCount[msg.Author.Id] > maxNumberOfPunishments)
+                        {
+                            // if the muted role is set and we are not banning people
+                            if (mutedRole != null && !banOffenders)
+                            {
+                                var guildUser = guild.GetUser(msg.Author.Id);
+                                try
+                                {
+                                    await guildUser.AddRoleAsync(mutedRole);
+                                    await msg.Channel.SendMessageAsync(msg.Author.Mention + " you have received too many warnings. You are muted as a result.");
+                                    return;
+                                }
+                                catch (Exception e)
+                                {
+                                    Log.Error("Unable to mute user for raid protection: " + e);
+                                    return;
+                                }
+                            }
+                            else // ban user by default
+                            {
+                                try
+                                {
+                                    await guild.AddBanAsync(msg.Author, 1, "Raid Protection => Triggered too many bot responses");
+                                    return;
+                                }
+                                catch (Exception e)
+                                {
+                                    Log.Error("Unable to ban user for raid protection: " + e);
+                                    return;
+                                }
+
+                            }
+
+                        }
+                    }
+                    await msg.DeleteAsync();
+                    return;
+                }
+            });
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/Floofbot/Services/RaidProtectionService.cs
+++ b/Floofbot/Services/RaidProtectionService.cs
@@ -61,11 +61,14 @@ namespace Floofbot.Services
         {
             RaidProtectionConfig serverConfig = _floofDb.RaidProtectionConfigs.Find(guild.Id);
             return serverConfig;
-        }        
+        }
         private async Task NotifyModerators(SocketRole modRole, ITextChannel modChannel, string message)
         {
             if (modRole == null || modChannel == null || string.IsNullOrEmpty(message))
+            {
+                Log.Information("Unable to notify moderators of a possible raid with reason: ``" + message + "``");
                 return;
+            }
             await modChannel.SendMessageAsync(modRole.Mention + " there may be a possible raid! Reason: ``" + message + "``");
         }
         private async void SendMessageAndDelete(string messageContent, ISocketMessageChannel channel)
@@ -146,6 +149,8 @@ namespace Floofbot.Services
 
                     // we run an async task to remove their point after the specified duration
                     UserPunishmentTimeout(guildId, msg.Author.Id);
+
+                    Log.Information("User ID " + msg.Author.Id + " triggered excess message spam and received a warning.");
                     return true;
                 }
             }
@@ -179,6 +184,7 @@ namespace Floofbot.Services
                 {
                     Log.Error("Error banning user for mass mention: " + e);
                 }
+                Log.Information("User ID " + msg.Author.Id + " triggered excess mention spam and was banned.");
                 return true;
             }
             return false;
@@ -204,6 +210,8 @@ namespace Floofbot.Services
                     UserPunishmentTimeout(guildId, msg.Author.Id);
 
                     SendMessageAndDelete(msg.Author.Mention + " no spamming!", msg.Channel);
+
+                    Log.Information("User ID " + msg.Author.Id + " triggered excess letter spam and received a warning.");
 
                     // we return here because we only need to check for at least one match, doesnt matter if there are more
                     return true;
@@ -231,6 +239,8 @@ namespace Floofbot.Services
 
                 SendMessageAndDelete(msg.Author.Mention + " no invite links!", msg.Channel);
 
+                Log.Information("User ID " + msg.Author.Id + " triggered invite link spam and received a warning.");
+
                 // we return here because we only need to check for at least one match, doesnt matter if there are more
                 return true;
             }
@@ -255,6 +265,8 @@ namespace Floofbot.Services
                 }
                 // we run an async task to remove their point after the specified duration
                 UserPunishmentTimeout(guildId, msg.Author.Id);
+
+                Log.Information("User ID " + msg.Author.Id + " triggered emoji spam and received a warning.");
 
                 SendMessageAndDelete(msg.Author.Mention + " do not spam emojis!", msg.Channel);
 
@@ -282,6 +294,7 @@ namespace Floofbot.Services
                     var modRole = (serverConfig.ModRoleId != null) ? server.GetRole((ulong)serverConfig.ModRoleId) : null;
                     var modChannel = (serverConfig.ModChannelId != null) ? server.GetChannel((ulong)serverConfig.ModChannelId) as ITextChannel : null;
                     await NotifyModerators(modRole, modChannel, "Excessive number of new joins in short time period.");
+                    Log.Information("An excessive number of joins was detected in server ID " + server.Id);
                     numberOfJoins[guild] = 0;
                     return;
                 }

--- a/Floofbot/Services/RaidProtectionService.cs
+++ b/Floofbot/Services/RaidProtectionService.cs
@@ -66,7 +66,11 @@ namespace Floofbot.Services
         {
             await Task.Delay(forgivenDuration);
             if (userPunishmentCount.ContainsKey(userid) && userPunishmentCount[userid] != 0)
-                    userPunishmentCount[userid] -= 1;
+            {
+                userPunishmentCount[userid] -= 1;
+                if (userPunishmentCount[userid] == 0)
+                    userPunishmentCount.Remove(userid);
+            }
         }
         private async void punishedUsersTimeout(SocketUser user)
         {
@@ -78,7 +82,12 @@ namespace Floofbot.Services
         {
             await Task.Delay(userJoinsDelay);
             if (numberOfJoins.ContainsKey(guild) && numberOfJoins[guild] != 0)
-                    numberOfJoins[guild] -= 1;
+            {
+                numberOfJoins[guild] -= 1;
+                if (numberOfJoins[guild] == 0)
+                    numberOfJoins.Remove(guild);
+            }
+                        
         }
         private async void UserMessageCountTimeout(ulong userid)
         {

--- a/Floofbot/Services/RaidProtectionService.cs
+++ b/Floofbot/Services/RaidProtectionService.cs
@@ -51,12 +51,6 @@ namespace Floofbot.Services
         // The max number of repeated emojis before triggering the raid protection
         private static int maxNumberEmojis = 5;
 
-
-
-        public RaidProtectionService()
-        {
-
-        }
         public RaidProtectionConfig GetServerConfig(IGuild guild, FloofDataContext _floofDb)
         {
             RaidProtectionConfig serverConfig = _floofDb.RaidProtectionConfigs.Find(guild.Id);

--- a/Floofbot/Services/RaidProtectionService.cs
+++ b/Floofbot/Services/RaidProtectionService.cs
@@ -63,8 +63,7 @@ namespace Floofbot.Services
         private async void UserPunishmentTimeout(ulong userid)
         {
             await Task.Delay(forgivenDuration);
-            if (userPunishmentCount.ContainsKey(userid))
-                if (userPunishmentCount[userid] != 0)
+            if (userPunishmentCount.ContainsKey(userid) && userPunishmentCount[userid] != 0)
                     userPunishmentCount[userid] -= 1;
         }
         private async void punishedUsersTimeout(SocketUser user)
@@ -76,8 +75,7 @@ namespace Floofbot.Services
         private async void userJoinTimeout(IGuild guild)
         {
             await Task.Delay(userJoinsDelay);
-            if (numberOfJoins.ContainsKey(guild))
-                if (numberOfJoins[guild] != 0)
+            if (numberOfJoins.ContainsKey(guild) && numberOfJoins[guild] != 0)
                     numberOfJoins[guild] -= 1;
         }
         private async void UserMessageCountTimeout(ulong userid)

--- a/Floofbot/Services/RaidProtectionService.cs
+++ b/Floofbot/Services/RaidProtectionService.cs
@@ -208,7 +208,7 @@ namespace Floofbot.Services
         {
             // check for repeated custom and normal emojis. 
             // custom emojis have format <:name:id> and normal emojis use unicode emoji
-            var regex = "( ?<:.*:[0-9]*> ?| ?(\u00a9|\u00ae|[\u2000-\u3300]|\ud83c[\ud000-\udfff]|\ud83d[\ud000-\udfff]|\ud83e[\ud000-\udfff]) ?){" + maxNumberEmojis + ",}";
+            var regex = "( ?(<:.*:[0-9]*>)|(\u00a9|\u00ae|[\u2000-\u3300]|\ud83c[\ud000-\udfff]|\ud83d[\ud000-\udfff]|\ud83e[\ud000-\udfff]) ?){" + maxNumberEmojis + ",}";
             var matchEmoji = Regex.Match(msg.Content, regex);
             if (matchEmoji.Success) // emoji spam
             {

--- a/Floofbot/Services/RaidProtectionService.cs
+++ b/Floofbot/Services/RaidProtectionService.cs
@@ -265,10 +265,10 @@ namespace Floofbot.Services
         }
         public async Task CheckForExcessiveJoins(IGuild guild)
         {
-            var _floofDb = new FloofDataContext();
             var server = guild as SocketGuild;
             if (server == null)
                 return;
+            var _floofDb = new FloofDataContext();
             var serverConfig = GetServerConfig(guild, _floofDb);
             // raid protection not configured
             if (serverConfig == null)

--- a/Floofbot/Services/RaidProtectionService.cs
+++ b/Floofbot/Services/RaidProtectionService.cs
@@ -25,7 +25,9 @@ namespace Floofbot.Services
         // used to keep track of the number of messages a user sent for spam protection
         private Dictionary<ulong, int> userMessageCount = new Dictionary<ulong, int>();
         // a list of punished users used to detect any potential raids
-        private List<SocketUser> punishedUsers = new List<SocketUser>();  
+        private List<SocketUser> punishedUsers = new List<SocketUser>();
+        // the total number of mentions a user can have before taking action
+        private static int maxMentionCount = 10;
         // determines how long before a user is forgiven for a punishment
         private static int forgivenDuration = 5 * 60 * 1000; // 5 min
         // determines the rate at which users can send messages, currently no more than x messages in y seconds
@@ -126,7 +128,7 @@ namespace Floofbot.Services
         }
         public async Task<bool> CheckMentions(SocketUserMessage msg, IGuild guild, SocketRole modRole, ITextChannel modChannel)
         {
-            if (msg.MentionedUsers.Count > 10)
+            if (msg.MentionedUsers.Count > maxMentionCount)
             {
                 string reason = "Raid Protection =>" + msg.MentionedUsers.Count + " mentions in one message.";
                 try

--- a/Floofbot/Services/RaidProtectionService.cs
+++ b/Floofbot/Services/RaidProtectionService.cs
@@ -140,7 +140,7 @@ namespace Floofbot.Services
                     builder.AddField("Reason", reason);
                     builder.Color = Discord.Color.Red;
                     await msg.Author.SendMessageAsync("", false, builder.Build());
-                    await guild.AddBanAsync(msg.Author, 1, reason);
+                    await guild.AddBanAsync(msg.Author, 0, reason);
 
                     await NotifyModerators(modRole, modChannel, " I have banned a user for mentioning " + msg.MentionedUsers.Count() + " members");
                 }
@@ -368,7 +368,7 @@ namespace Floofbot.Services
                                 builder.AddField("Reason", reason);
                                 builder.Color = Discord.Color.Red;
                                 await msg.Author.SendMessageAsync("", false, builder.Build());
-                                await guild.AddBanAsync(msg.Author, 1, reason);
+                                await guild.AddBanAsync(msg.Author, 0, reason);
                             }
                             catch (Exception e)
                             {

--- a/Floofbot/Services/RaidProtectionService.cs
+++ b/Floofbot/Services/RaidProtectionService.cs
@@ -64,6 +64,8 @@ namespace Floofbot.Services
         }        
         private async Task NotifyModerators(SocketRole modRole, ITextChannel modChannel, string message)
         {
+            if (modRole == null || modChannel == null || string.IsNullOrEmpty(message))
+                return;
             await modChannel.SendMessageAsync(modRole.Mention + " there may be a possible raid! Reason: ``" + message + "``");
         }
         private async void SendMessageAndDelete(string messageContent, ISocketMessageChannel channel)

--- a/Floofbot/Services/RaidProtectionService.cs
+++ b/Floofbot/Services/RaidProtectionService.cs
@@ -23,7 +23,7 @@ namespace Floofbot.Services
         // used to keep track of the number of messages a user sent for spam protection
         private Dictionary<ulong, int> userMessageCount = new Dictionary<ulong, int>();
         // determines how long before a user is forgiven for a punishment - currently 5 min
-        private static int forgivenDuration = 1 * 60 * 1000;
+        private static int forgivenDuration = 5 * 60 * 1000;
         // determines the rate at which users can send messages, currently no more than x messages in 5 seconds
         private static int durationForMaxMessages = 5 * 1000;
         // determines the max number of punishments a user can have before being punished

--- a/Floofbot/Services/RaidProtectionService.cs
+++ b/Floofbot/Services/RaidProtectionService.cs
@@ -303,18 +303,14 @@ namespace Floofbot.Services
                 return false;
             // can return null
             var channel = userMsg.Channel as ITextChannel;
-            if (channel == null)
-                return false;
-            // can return null
             var guild = channel.Guild as SocketGuild;
-            if (guild == null)
+
+            if (channel == null || guild == null)
                 return false;
+
             var serverConfig = GetServerConfig(guild, _floofDb);
-            // raid protection not configured
-            if (serverConfig == null)
-                return false;
-            // raid protection disabled
-            if (!serverConfig.Enabled)
+            // raid protection not configured or disabled
+            if (serverConfig == null || !serverConfig.Enabled)
                 return false;
 
             // users with the exceptions role are immune to raid protection

--- a/Floofbot/Services/RaidProtectionService.cs
+++ b/Floofbot/Services/RaidProtectionService.cs
@@ -270,11 +270,8 @@ namespace Floofbot.Services
                 return;
             var _floofDb = new FloofDataContext();
             var serverConfig = GetServerConfig(guild, _floofDb);
-            // raid protection not configured
-            if (serverConfig == null)
-                return;
-            // raid protection disabled
-            if (!serverConfig.Enabled)
+            // raid protection not configured or disabled
+            if (serverConfig == null || !serverConfig.Enabled)
                 return;
             // increment user join count for guild
             if (numberOfJoins.ContainsKey(guild))

--- a/Floofbot/Services/RaidProtectionService.cs
+++ b/Floofbot/Services/RaidProtectionService.cs
@@ -286,7 +286,7 @@ namespace Floofbot.Services
                     return;
                 }
             }
-            else // they were a good boye but now they are not
+            else // add 1 to number of joins in that guild
             {
                 numberOfJoins.Add(guild, 1);
             }

--- a/Floofbot/Services/RaidProtectionService.cs
+++ b/Floofbot/Services/RaidProtectionService.cs
@@ -212,7 +212,7 @@ namespace Floofbot.Services
         }
         private bool CheckInviteLinks(SocketMessage msg, ulong guildId)
         {
-            var regex = "(https?:\\/\\/)?(www\\.)?((d(iscord)?\\.gg)|(discord(app)?\\.com))/+\\w{5,}/?";
+            var regex = "(https?:\\/\\/)?(www\\.)?((discord(app)?\\.com\\/invite)|(discord\\.(gg|io|me|li)))\\/+\\w{2,}\\/?";
             if (Regex.IsMatch(msg.Content, regex))
             {
                 // add a bad boye point for the user

--- a/Floofbot/Services/RaidProtectionService.cs
+++ b/Floofbot/Services/RaidProtectionService.cs
@@ -39,7 +39,7 @@ namespace Floofbot.Services
         private static int maxNumberPunishedUsers = 3;
         // These are used to determine if there are an excessive number of joins in a short time frame
         private static int maxNumberOfJoins = 5;
-        private static int userJoinsDelay = 2 * 60 * 1000; // 2 sec
+        private static int userJoinsDelay = 2 * 60 * 1000; // 2 min
         private Dictionary<IGuild, int> numberOfJoins = new Dictionary<IGuild, int>();
 
 

--- a/Floofbot/Services/RaidProtectionService.cs
+++ b/Floofbot/Services/RaidProtectionService.cs
@@ -208,7 +208,8 @@ namespace Floofbot.Services
         }
         public async Task<bool> CheckInviteLinks(SocketMessage msg, ulong guildId)
         {
-            if (msg.Content.Contains("discord.gg") || msg.Content.Contains("d.gg"))
+            var regex = "(https?:\\/\\/)?(www\\.)?((d(iscord)?\\.gg)|(discord(app)?\\.com))/+\\w{5,}/?";
+            if (Regex.IsMatch(msg.Content, regex))
             {
                 // add a bad boye point for the user
                 if (userPunishmentCount[guildId].ContainsKey(msg.Author.Id))

--- a/Floofbot/Services/RaidProtectionService.cs
+++ b/Floofbot/Services/RaidProtectionService.cs
@@ -123,7 +123,7 @@ namespace Floofbot.Services
             UserMessageCountTimeout(msg.Author.Id);
             return false;
         }
-        public async Task<bool> CheckMentions(SocketUserMessage msg, IGuild guild)
+        public async Task<bool> CheckMentions(SocketUserMessage msg, IGuild guild, SocketRole modRole, ITextChannel modChannel)
         {
             if (msg.MentionedUsers.Count > 10)
             {
@@ -138,6 +138,8 @@ namespace Floofbot.Services
                     builder.Color = Discord.Color.Red;
                     await msg.Author.SendMessageAsync("", false, builder.Build());
                     await guild.AddBanAsync(msg.Author, 1, reason);
+
+                    await NotifyModerators(modRole, modChannel, " I have banned a user for mentioning " + msg.MentionedUsers.Count() + " members");
                 }
                 catch (Exception e)
                 {
@@ -282,7 +284,7 @@ namespace Floofbot.Services
             // now we run our checks. If any of them return true, we have a bad boy
 
             // this will ALWAYS ban users regardless of muted role or not 
-            bool spammedMentions = CheckMentions(userMsg, guild).Result;
+            bool spammedMentions = CheckMentions(userMsg, guild, modRole, modChannel).Result;
             // this will check their messages and see if they are spamming
             bool userSpammedMessages = CheckUserMessageCount(userMsg).Result;
             // this checks for spamming letters in a row

--- a/Floofbot/Services/Repository/FloofDataContext.cs
+++ b/Floofbot/Services/Repository/FloofDataContext.cs
@@ -28,6 +28,7 @@ namespace Floofbot.Services.Repository
         public virtual DbSet<BanOnJoin> BansOnJoin { get; set; }
         public virtual DbSet<ModMail> ModMails { get; set; }
         public virtual DbSet<ErrorLogging> ErrorLoggingConfigs { get; set; }
+        public virtual DbSet<RaidProtectionConfig> RaidProtectionConfigs { get; set; }
         protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
         {
             if (!optionsBuilder.IsConfigured)

--- a/Floofbot/Services/Repository/Models/RaidProtectionConfig.cs
+++ b/Floofbot/Services/Repository/Models/RaidProtectionConfig.cs
@@ -1,0 +1,17 @@
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace Floofbot.Services.Repository.Models
+{
+    public partial class RaidProtectionConfig
+    {
+        [Key]
+        public ulong ServerId { get; set; }
+        public bool Enabled { get; set; }
+        public ulong? ModChannelId { get; set; }
+        public ulong? ModRoleId { get; set; }
+        public ulong? MutedRoleId { get; set; }
+        public ulong? ExceptionRoleId { get; set; }
+        public bool BanOffenders { get; set; }
+    }
+}
+


### PR DESCRIPTION
The rules for triggering the raid protection are:
- Over 10 Mass mention spams (instant ban)
- Over 3 user strikes within 5 mins
- - Can gain from spamming 5 messages in 5 seconds
- - Can gain from posting invite links
- - Can gain from spamming the same letter over 5 times in a row
- - Can gain from spamming 5 emojis both custom and normal
- After 5 minutes, the user is forgiven

Mod alerts when
- Over 3 users have been punished within 30 mins
- Over 5 users joined in 2 mins
- A user has been autobanned for mention spam

Options:
- Toggle on/off the raid protection
- Set a muted role
- Set a mod role to ping for alerts
- Set a mod channel to send mod alerts to
- Toggle on/off banning instead of muting (mute role must be set to disable this)
- Add an exceptions role which is not affected by raid protection