### PR TITLE
Various minor fixes

### DIFF
--- a/Floofbot/Handlers/CommandHandler.cs
+++ b/Floofbot/Handlers/CommandHandler.cs
@@ -66,6 +66,8 @@ namespace Floofbot.Handlers
 
             var userMsg = originalMessage as SocketUserMessage; // the original command
             var channel = userMsg.Channel as ITextChannel; // the channel of the original command
+            if (channel == null)
+                return;
 
             var serverConfig = _floofDb.ErrorLoggingConfigs.Find(channel.GuildId); // no db result
             if (serverConfig == null)

--- a/Floofbot/Modules/Filter.cs
+++ b/Floofbot/Modules/Filter.cs
@@ -114,7 +114,7 @@ namespace Floofbot.Modules
 
         [Summary("Adds a new filtered word")]
         [Command("add")]
-        public async Task AddFilteredWord([Summary("filtered word")]string word)
+        public async Task AddFilteredWord([Summary("filtered word")][Remainder] string word)
         {
             CheckServerEntryExists(Context.Guild.Id);
             string newWord = word.ToLower();
@@ -146,7 +146,7 @@ namespace Floofbot.Modules
         }
         [Summary("Removed an existing filtered word")]
         [Command("remove")]
-        public async Task RemoveFilteredWord([Summary("filtered word")]string word)
+        public async Task RemoveFilteredWord([Summary("filtered word")][Remainder] string word)
         {
             CheckServerEntryExists(Context.Guild.Id);
             string oldWord = word.ToLower();

--- a/Floofbot/Modules/UserAssignableRoleCommands.cs
+++ b/Floofbot/Modules/UserAssignableRoleCommands.cs
@@ -12,6 +12,7 @@ using Serilog;
 
 namespace Floofbot.Modules
 {
+    [RequireContext(ContextType.Guild)]
     [Summary("Add/Remove allowable roles for yourself")]
     public class UserAssignableRoleCommands : InteractiveBase
     {


### PR DESCRIPTION
* Prevents errors from getting eaten when they are raised from a command issued in a DM.
* Change the word filter add/remove commands to not require the use of quotes
* Enforced guild context requirement for iam/iamnot commands