### PR TITLE
Ignore edited messages if content is same

### DIFF
--- a/Floofbot/Handlers/CommandHandler.cs
+++ b/Floofbot/Handlers/CommandHandler.cs
@@ -96,6 +96,9 @@ namespace Floofbot.Handlers
             if (messageBefore == null)
                 return;
 
+            if (messageBefore.Content == after.Content)
+                return;
+
             if (messageBefore.EditedTimestamp == null) // user has never edited their message
             {
                 var timeDifference = DateTimeOffset.Now - messageBefore.Timestamp;


### PR DESCRIPTION
This prevents commands from being fired twice when a large embed image preview is posted, which triggers the edited message handler