### PR TITLE
XKCD now gets latest on no argument

### DIFF
--- a/Floofbot/Modules/Fun.cs
+++ b/Floofbot/Modules/Fun.cs
@@ -32,19 +32,27 @@ namespace Floofbot.Modules
         public async Task XKCD([Summary("Comic ID")] string comicId = "")
         {
             int parsedComicId;
-            if (!int.TryParse(comicId, out parsedComicId) || parsedComicId <= 0)
+            if ((!int.TryParse(comicId, out parsedComicId) || parsedComicId <= 0) && !comicId.ToLower().Equals(""))
             {
-                await Context.Channel.SendMessageAsync("Comic ID must be a positive integer less than or equal to Int32.MaxValue.");
+                await Context.Channel.SendMessageAsync("Comic ID must be a positive integer less than or equal to " + Int32.MaxValue + ".");
                 return;
             }
 
-            string json = await ApiFetcher.RequestSiteContentAsString($"https://xkcd.com/{comicId}/info.0.json");
+            string json;
+            if (parsedComicId == 0)
+            {
+                json = await ApiFetcher.RequestSiteContentAsString("https://xkcd.com/info.0.json");
+            }
+            else
+            {
+                json = await ApiFetcher.RequestSiteContentAsString($"https://xkcd.com/{comicId}/info.0.json");
+            }
+
             if (string.IsNullOrEmpty(json))
             {
                 await Context.Channel.SendMessageAsync("404 Not Found");
                 return;
             }
-
             string imgLink;
             string imgHoverText;
             string comicTitle;

--- a/Floofbot/Modules/Fun.cs
+++ b/Floofbot/Modules/Fun.cs
@@ -32,7 +32,7 @@ namespace Floofbot.Modules
         public async Task XKCD([Summary("Comic ID")] string comicId = "")
         {
             int parsedComicId;
-            if ((!int.TryParse(comicId, out parsedComicId) || parsedComicId <= 0) && !comicId.ToLower().Equals(""))
+            if ((!int.TryParse(comicId, out parsedComicId) || parsedComicId <= 0) && !String.IsNullOrEmpty(comicId))
             {
                 await Context.Channel.SendMessageAsync("Comic ID must be a positive integer less than or equal to " + Int32.MaxValue + ".");
                 return;


### PR DESCRIPTION
Previously, the XKCD command would just spit out an error message with a
possibly unknown value to some. I changed this around so that it now
gets the latest XKCD comic with no argument given (as it says in the
help command and module summary), as well as gives the actual integer
value for the maximum comic ID.