### PR TITLE
Updated Raid Protection To Include Timestamps

### DIFF
--- a/Floofbot/Services/RaidProtectionService.cs
+++ b/Floofbot/Services/RaidProtectionService.cs
@@ -3,20 +3,11 @@ using Discord.WebSocket;
 using Floofbot.Configs;
 using Floofbot.Services.Repository;
 using Floofbot.Services.Repository.Models;
-using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.SignalR;
-using Microsoft.AspNetCore.WebUtilities;
 using Serilog;
 using System;
-using System.Collections;
 using System.Collections.Generic;
-using System.Diagnostics.Eventing.Reader;
 using System.Linq;
-using System.Net.NetworkInformation;
-using System.Security.Policy;
-using System.Text;
 using System.Text.RegularExpressions;
-using System.Threading.Channels;
 using System.Threading.Tasks;
 
 namespace Floofbot.Services

--- a/Floofbot/Services/RaidProtectionService.cs
+++ b/Floofbot/Services/RaidProtectionService.cs
@@ -160,7 +160,6 @@ namespace Floofbot.Services
                 else
                     return false;
 
-
                 if (userMessageCount[guildId][msg.Author.Id] >= maxMessageSpam) // no more than 2 messages in time frame
                 {
                     // add a bad boye point for the user

--- a/Floofbot/Services/RaidProtectionService.cs
+++ b/Floofbot/Services/RaidProtectionService.cs
@@ -177,6 +177,7 @@ namespace Floofbot.Services
                 else
                 {
                     lastUserMessageInGuild[guildId].Add(msg.Author.Id, msg);
+                    return false;
                 }
 
                 // compare timestamps of messages

--- a/Floofbot/Services/RaidProtectionService.cs
+++ b/Floofbot/Services/RaidProtectionService.cs
@@ -63,13 +63,6 @@ namespace Floofbot.Services
             durationBetweenMessages = raidConfig["DurationBetweenMessages"];
             maxMessageSpam = raidConfig["MaxMessageSpam"];
         }
-        private async Task HandleBadMessage(SocketUser user, SocketMessage msg)
-        {
-            await msg.DeleteAsync();
-            var botMsg = await msg.Channel.SendMessageAsync($"{user.Mention} There was a filtered word in that message. Please be mindful of your language!");
-            await Task.Delay(5000);
-            await botMsg.DeleteAsync();
-        }
         public RaidProtectionConfig GetServerConfig(IGuild guild, FloofDataContext _floofDb)
         {
             RaidProtectionConfig serverConfig = _floofDb.RaidProtectionConfigs.Find(guild.Id);
@@ -193,7 +186,7 @@ namespace Floofbot.Services
                 else
                     return false;
 
-                if (userMessageCount[guildId][msg.Author.Id] >= maxMessageSpam) // no more than 2 messages in time frame
+                if (userMessageCount[guildId][msg.Author.Id] >= maxMessageSpam) // no more than a defined number of messages in time frame
                 {
                     // add a bad boye point for the user
                     if (userPunishmentCount[guildId].ContainsKey(msg.Author.Id))

--- a/Floofbot/Services/WordFilterService.cs
+++ b/Floofbot/Services/WordFilterService.cs
@@ -1,0 +1,82 @@
+﻿using Floofbot.Services.Repository;
+using Floofbot.Services.Repository.Models;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace Floofbot.Services
+{
+    class WordFilterService
+    {
+        List<FilteredWord> _filteredWords;
+        DateTime _lastRefreshedTime;
+        WordFilterService _wordFilterService;
+
+        public bool hasFilteredWord(FloofDataContext floofDb, string messageContent, ulong serverId) // names
+        {
+            // return false if none of the serverIds match or filtering has been disabled for the server
+            if (!floofDb.FilterConfigs.AsQueryable()
+                .Any(x => x.ServerId == serverId && x.IsOn))
+            {
+                return false;
+            }
+
+            DateTime currentTime = DateTime.Now;
+            if (_lastRefreshedTime == null || currentTime.Subtract(_lastRefreshedTime).TotalMinutes >= 30)
+            {
+                _filteredWords = floofDb.FilteredWords.AsQueryable()
+                    .Where(x => x.ServerId == serverId).ToList();
+                _lastRefreshedTime = currentTime;
+            }
+
+            foreach (var filteredWord in _filteredWords)
+            {
+                Regex r = new Regex($"{filteredWord.Word}",
+                    RegexOptions.IgnoreCase | RegexOptions.Singleline);
+                if (r.IsMatch(messageContent))
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
+        public bool hasFilteredWord(FloofDataContext floofDb, string messageContent, ulong serverId, ulong channelId) // messages
+        {
+            // return false if none of the serverIds match or filtering has been disabled for the server
+            if (!floofDb.FilterConfigs.AsQueryable()
+                .Any(x => x.ServerId == serverId && x.IsOn))
+            {
+                return false;
+            }
+
+            // whitelist means we don't have the filter on for this channel
+            if (floofDb.FilterChannelWhitelists.AsQueryable()
+                .Any(x => x.ChannelId == channelId && x.ServerId == serverId))
+            {
+                return false;
+            }
+
+            DateTime currentTime = DateTime.Now;
+            if (_lastRefreshedTime == null || currentTime.Subtract(_lastRefreshedTime).TotalMinutes >= 30)
+            {
+                _filteredWords = floofDb.FilteredWords.AsQueryable()
+                    .Where(x => x.ServerId == serverId).ToList();
+                _lastRefreshedTime = currentTime;
+            }
+
+            foreach (var filteredWord in _filteredWords)
+            {
+                Regex r = new Regex(@$"\b({filteredWord.Word})\b",
+                    RegexOptions.IgnoreCase | RegexOptions.Singleline);
+                if (r.IsMatch(messageContent))
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
+    }
+
+}

--- a/Floofbot/Services/WordFilterService.cs
+++ b/Floofbot/Services/WordFilterService.cs
@@ -12,7 +12,6 @@ namespace Floofbot.Services
     {
         List<FilteredWord> _filteredWords;
         DateTime _lastRefreshedTime;
-        WordFilterService _wordFilterService;
 
         public bool hasFilteredWord(FloofDataContext floofDb, string messageContent, ulong serverId) // names
         {

--- a/Floofbot/config.yaml.sample
+++ b/Floofbot/config.yaml.sample
@@ -56,6 +56,10 @@ RaidProtection:
   ForgivenDuration: 300000
   # determines the rate at which users can send messages, currently no more than x messages in y seconds
   DurationForMaxMessages: 5000
+  # determines the minimum duration between two user messages before they are counted as spam
+  DurationBetweenMessages: 500
+  # determines the max number of spam messages a user can send before being warned
+  MaxMessageSpam: 3
   # determines the max number of punishments a user can have before being punished
   MaxNumberOfPunishments: 3
   # the delay before the bot msg is deleted in ms


### PR DESCRIPTION
- Several parameters have been set to configurable variables
- Users last sent message in a server is now recorded to compare timestamps
- This means that if there is API lag or the discord bot lags, it will not trigger false positives in raid protection
- Word filter service is implemented into raid protection