### PR TITLE
Add basic container building

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,8 +54,13 @@ jobs:
     needs: build
     if: github.event_name == 'push' && github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
+    outputs:
+      cr_pat_exists: ${{ steps.pat_check.outputs.cr_pat_exists }}
+      new_release_version: ${{ steps.get_new_release_version.outputs.new_version }}
     steps:
-    - name: Get new release number
+
+    - name: Get new release version
+      id: get_new_release_version
       shell: bash
       env:
         ACTIONS_ALLOW_UNSECURE_COMMANDS: true
@@ -65,7 +70,11 @@ jobs:
         cur_version = json.load(sys.stdin).get('name', '0.0.0.0').rsplit('.', 1);
         new_version = datetime.datetime.utcnow().strftime('%Y.%m.%d'), -1;
         base, patch = new_version if new_version[0] != cur_version[0] else cur_version;
-        print(f'::set-env name=NEW_VERSION::{base}.{int(patch) + 1}')"
+        print('::set-env name=NEW_VERSION::{0}\n::set-output name=new_version::{0}'.format(f'{base}.{int(patch) + 1}'))"
+
+    - name: Set secret existence variable
+      id: pat_check
+      run: echo "::set-output name=cr_pat_exists::$([ -z "${{ secrets.CR_PAT }}" ] && echo "false" || echo "true")"
 
     - name: Download built artifacts
       uses: actions/download-artifact@v2
@@ -123,3 +132,43 @@ jobs:
         asset_path: config.yaml.sample
         asset_name: config.yaml.sample
         asset_content_type: text/plain
+
+  ## Uploads a new Docker image of the build. Requires the release step for the version variable
+  release_image:
+    needs: release
+    if: needs.release.outputs.cr_pat_exists == 'true'
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: Checkout repository for Dockerfile and scripts
+      uses: actions/checkout@v2
+
+    - name: Download built artifacts
+      uses: actions/download-artifact@v2
+      with:
+        name: build_artifacts
+
+    - name: Extract build binary
+      shell: bash
+      run: 'mkdir -p artifacts/linux-musl-x64 && tar -C artifacts/linux-musl-x64 -xf Floofbot_linux-musl-x64.tar.gz'
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v1
+
+    - name: Login to GitHub Container Registry
+      uses: docker/login-action@v1
+      with:
+        registry: ghcr.io
+        username: ${{ github.repository_owner }}
+        password: ${{ secrets.CR_PAT }}
+
+    - name: Docker build and push
+      uses: docker/build-push-action@v2
+      with:
+        context: .
+        file: ./Dockerfile
+        platforms: linux/amd64
+        push: true
+        tags: |
+          ghcr.io/${{ github.repository_owner }}/floofbot:latest
+          ghcr.io/${{ github.repository_owner }}/floofbot:${{ needs.release.outputs.new_release_version }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,7 +55,6 @@ jobs:
     if: github.event_name == 'push' && github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     outputs:
-      cr_pat_exists: ${{ steps.pat_check.outputs.cr_pat_exists }}
       new_release_version: ${{ steps.get_new_release_version.outputs.new_version }}
     steps:
 
@@ -71,10 +70,6 @@ jobs:
         new_version = datetime.datetime.utcnow().strftime('%Y.%m.%d'), -1;
         base, patch = new_version if new_version[0] != cur_version[0] else cur_version;
         print('::set-env name=NEW_VERSION::{0}\n::set-output name=new_version::{0}'.format(f'{base}.{int(patch) + 1}'))"
-
-    - name: Set secret existence variable
-      id: pat_check
-      run: echo "::set-output name=cr_pat_exists::$([ -z "${{ secrets.CR_PAT }}" ] && echo "false" || echo "true")"
 
     - name: Download built artifacts
       uses: actions/download-artifact@v2
@@ -136,7 +131,6 @@ jobs:
   ## Uploads a new Docker image of the build. Requires the release step for the version variable
   release_image:
     needs: release
-    if: needs.release.outputs.cr_pat_exists == 'true'
     runs-on: ubuntu-latest
     steps:
 
@@ -160,7 +154,7 @@ jobs:
       with:
         registry: ghcr.io
         username: ${{ github.repository_owner }}
-        password: ${{ secrets.CR_PAT }}
+        password: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Docker build and push
       uses: docker/build-push-action@v2

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+# This Dockerfile is just used to facilitate the GitHub Actions CI build
+# (it produces the binary outside of the Docker build)
+
+FROM alpine:latest
+
+# dependencies
+RUN apk add --no-cache libintl libstdc++
+
+# Set and add working directory
+WORKDIR /root/
+RUN mkdir data
+
+# Copy files
+COPY Floofbot/Scripts/LinuxDBBackup.sh .
+COPY artifacts/linux-musl-x64/Floofbot .
+
+# Fix for running in a container
+ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=1
+
+ENTRYPOINT ["./Floofbot"]
+CMD ["data/config.yaml"]


### PR DESCRIPTION
This adds support for basic container building and pushing. The GitHub Actions job will not run unless a `CR_PAT` secret variable is added, but this has been tested on my fork.

To pull the test image from that fork, run `docker pull ghcr.io/jkchen2/floofbot:latest`

EDIT: I should note that when the secret token has been added, built images will be pushed to Beals' repository at `ghcr.io/bealsbe/floofbot`

EDIT 2: Should also mention that `CR_PAT` is a [personal access token with scoped read/write permissions for GitHub Packages](https://docs.github.com/en/free-pro-team@latest/packages/getting-started-with-github-container-registry/migrating-to-github-container-registry-for-docker-images#authenticating-with-the-container-registry). This will allow the CI build to push built images to the GitHub Container Registry.