### PR TITLE
Miscellaneous fixes

### DIFF
--- a/Floofbot/Handlers/RandomResponseGenerator.cs
+++ b/Floofbot/Handlers/RandomResponseGenerator.cs
@@ -8,6 +8,13 @@ class RandomResponseGenerator
 {
     public static string GenerateResponse(SocketUserMessage userMessage)
     {
+
+        // System messages (e.x. pin notifications)
+        if (userMessage == null)
+        {
+            return string.Empty;
+        }
+
         List<BotRandomResponse> responses = BotConfigFactory.Config.RandomResponses;
         if (responses == null || responses.Count == 0)
         {

--- a/Floofbot/Services/EventLoggerService.cs
+++ b/Floofbot/Services/EventLoggerService.cs
@@ -232,9 +232,16 @@ namespace Floofbot.Services
                     embed.WithTitle($"⚠️ Message Deleted | {message.Author.Username}#{message.Author.Discriminator}")
                          .WithColor(Color.Gold)
                          .WithDescription($"{message.Author.Mention} ({message.Author.Id}) has had their message deleted in {channel.Mention}!")
-                         .AddField("Content", message.Content)
                          .WithCurrentTimestamp()
                          .WithFooter($"user_message_deleted user_messagelog {message.Author.Id}");
+                    if (message.Content.Length > 0)
+                    {
+                        embed.AddField("Content", message.Content);
+                    }
+                    if (message.Attachments.Count > 0)
+                    {
+                        embed.AddField("Attachments", String.Join("\n", message.Attachments.Select(it => it.Url)));
+                    }
 
                     if (Uri.IsWellFormedUriString(message.Author.GetAvatarUrl(), UriKind.Absolute))
                         embed.WithThumbnailUrl(message.Author.GetAvatarUrl());


### PR DESCRIPTION
Fixes the message log erroring out when a message with just an attachment gets deleted. Now it logs attachment URLs (which likely can't resolve to an actual file as the message has been deleted)

Also fixes the random response handler erroring out when a system message (i.e. a user joined message or a message has been pinned notification) is received.