### PR TITLE
Improved Help Command

### DIFF
--- a/Floofbot/Modules/Administration.cs
+++ b/Floofbot/Modules/Administration.cs
@@ -17,7 +17,7 @@ using Discord.Net;
 namespace Floofbot.Modules
 {
     [Summary("Administration commands")]
-    [Discord.Commands.Name("Administration")]
+    [Name("Administration")]
     public class Administration : InteractiveBase
     {
         private static readonly Color ADMIN_COLOR = Color.DarkOrange;

--- a/Floofbot/Modules/ErrorLoggingCommands.cs
+++ b/Floofbot/Modules/ErrorLoggingCommands.cs
@@ -6,6 +6,7 @@ using Floofbot.Services.Repository.Models;
 using System.Threading.Tasks;
 
 [Summary("Error logging configuration commands")]
+[Name("Error Logging Configuration Commands")]
 [RequireUserPermission(GuildPermission.Administrator)]
 [Group("errorloggingconfig")]
 public class ErrorLoggingCommands : InteractiveBase

--- a/Floofbot/Modules/Filter.cs
+++ b/Floofbot/Modules/Filter.cs
@@ -13,7 +13,7 @@ using System.Collections.Generic;
 namespace Floofbot.Modules
 {
     [Summary("Settings that control the automatic word filtering in a server")]
-    [Discord.Commands.Name("Filter")]
+    [Name("Filter")]
     [Group("filter")]
     [Alias("f")]
     [RequireContext(ContextType.Guild)]

--- a/Floofbot/Modules/Fun.cs
+++ b/Floofbot/Modules/Fun.cs
@@ -9,7 +9,7 @@ using System.Threading.Tasks;
 namespace Floofbot.Modules
 {
     [Summary("Fun commands")]
-    [Discord.Commands.Name("Fun")]
+    [Name("Fun")]
     public class Fun : ModuleBase<SocketCommandContext>
     {
         private static readonly Discord.Color EMBED_COLOR = Color.DarkOrange;

--- a/Floofbot/Modules/Help.cs
+++ b/Floofbot/Modules/Help.cs
@@ -40,29 +40,36 @@ namespace Floofbot.Modules
             List<EmbedFieldBuilder> fields = new List<EmbedFieldBuilder>();
             List<PaginatedMessage.Page> pages = new List<PaginatedMessage.Page>();
             foreach (ModuleInfo module in modules)
-            {
+            { 
                 foreach (CommandInfo command in moduleCommands[module.Name])
                 {
-                    string aliases;
-                    if (command.Aliases != null)
-                        aliases = string.Join(", ", command.Aliases);
-                    else
-                        aliases = "None";
-
-                    fields.Add(new EmbedFieldBuilder()
+                    var userMeetsCommandPreconditions = await command.CheckPreconditionsAsync(Context);
+                    if (userMeetsCommandPreconditions.IsSuccess)
                     {
-                        Name = $"{command.Name} (aliases: {aliases})",
-                        Value = command.Summary ?? "No command description available",
-                        IsInline = false
-                    });
+                        string aliases;
+                        if (command.Aliases != null)
+                            aliases = string.Join(", ", command.Aliases);
+                        else
+                            aliases = "None";
+
+                        fields.Add(new EmbedFieldBuilder()
+                        {
+                            Name = $"{command.Name} (aliases: {aliases})",
+                            Value = command.Summary ?? "No command description available",
+                            IsInline = false
+                        });
+                    }
                 }
-                pages.Add(new PaginatedMessage.Page
+                if (fields.Count > 0) // don't show empty pages
                 {
-                    Author = new EmbedAuthorBuilder { Name = module.Name },
-                    Fields = new List<EmbedFieldBuilder>(fields),
-                    Description = module.Summary ?? "No module description available"
-                });
-                fields.Clear();
+                    pages.Add(new PaginatedMessage.Page
+                    {
+                        Author = new EmbedAuthorBuilder { Name = module.Name },
+                        Fields = new List<EmbedFieldBuilder>(fields),
+                        Description = module.Summary ?? "No module description available"
+                    });
+                    fields.Clear();
+                }
             }
 
             string message = Context.User.Mention;
@@ -82,30 +89,39 @@ namespace Floofbot.Modules
 
             IEnumerable<CommandInfo> moduleCommands = _commandService.Commands
                 .Where(command => command.Module.Name.ToLower() == requestedModule.ToLower());
+
             List<EmbedFieldBuilder> fields = new List<EmbedFieldBuilder>();
             List<PaginatedMessage.Page> pages = new List<PaginatedMessage.Page>();
             foreach (var cmd in moduleCommands)
             {
-                foreach (ParameterInfo param in cmd.Parameters)
+                var userMeetsCommandPreconditions = await cmd.CheckPreconditionsAsync(Context);
+                if (userMeetsCommandPreconditions.IsSuccess)
                 {
-                    fields.Add(new EmbedFieldBuilder()
+                    foreach (ParameterInfo param in cmd.Parameters)
                     {
-                        Name = param.Name,
-                        Value = param.Summary ?? "No parameter description available",
-                        IsInline = false
+                        fields.Add(new EmbedFieldBuilder()
+                        {
+                            Name = param.Name,
+                            Value = param.Summary ?? "No parameter description available",
+                            IsInline = false
+                        });
+                    }
+                    pages.Add(new PaginatedMessage.Page
+                    {
+                        Author = new EmbedAuthorBuilder { Name = cmd.Name },
+                        Fields = new List<EmbedFieldBuilder>(fields),
+                        Description = cmd.Summary ?? "No command description available"
                     });
+                    fields.Clear();
                 }
-                pages.Add(new PaginatedMessage.Page
-                {
-                    Author = new EmbedAuthorBuilder { Name = cmd.Name },
-                    Fields = new List<EmbedFieldBuilder>(fields),
-                    Description = cmd.Summary ?? "No command description available"
-                });
-                fields.Clear();
             }
-
-            string message = $"{Context.User.Mention} here are the commands available for '{requestedModule}'!";
-            await PostHelpPages(message, pages);
+            if (pages.Count > 0)
+            {
+                string message = $"{Context.User.Mention} here are the commands available for '{requestedModule}'!";
+                await PostHelpPages(message, pages);
+            }
+            else // user doesnt meet preconditions to use any of the commands in the module
+                return;
         }
 
         private async Task PostHelpPages(string message, List<PaginatedMessage.Page> pages)

--- a/Floofbot/Modules/Help.cs
+++ b/Floofbot/Modules/Help.cs
@@ -50,7 +50,7 @@ namespace Floofbot.Modules
                         if (userMeetsCommandPreconditions.IsSuccess)
                         {
                             string aliases = "";
-                            var aliasesWithoutCommandName = command.Aliases.Where(x => !x.Contains(command.Name) && !x.Contains(module.Group)); // remove the cmd name/group from aliases
+                            var aliasesWithoutCommandName = command.Aliases.Where(x => !x.Contains(command.Name)); // remove the cmd name/group from aliases
 
                             if (aliasesWithoutCommandName != null && aliasesWithoutCommandName.Any()) // is not null or empty
                                 aliases = "(aliases: " + string.Join(", ", aliasesWithoutCommandName) + ")";

--- a/Floofbot/Modules/Logging.cs
+++ b/Floofbot/Modules/Logging.cs
@@ -14,7 +14,7 @@ namespace Floofbot.Modules
     public class Logging
     {
         [Summary("Logging commands")]
-        [Discord.Commands.Name("Logger")]
+        [Name("Logger Configuration Commands")]
         [Group("logger")]
         [RequireUserPermission(GuildPermission.Administrator)]
         [RequireContext(ContextType.Guild)]

--- a/Floofbot/Modules/ModMail.cs
+++ b/Floofbot/Modules/ModMail.cs
@@ -16,6 +16,7 @@ using System.Threading.Tasks;
 namespace Floofbot.Modules
 {
     [Summary("Send a message directly to the server's moderators")]
+    [Name("ModMail")]
     [Group("modmail")]
     public class ModMailModule : InteractiveBase
     {

--- a/Floofbot/Modules/ModMail.cs
+++ b/Floofbot/Modules/ModMail.cs
@@ -28,6 +28,8 @@ namespace Floofbot.Modules
         }
 
         [Command("")]
+        [Name("modmail <content>")]
+        [Summary("Send a message to the moderators")]
         public async Task sendModMail([Summary("Message Content")][Remainder] string content = "")
         {
             try

--- a/Floofbot/Modules/NicknameAlert.cs
+++ b/Floofbot/Modules/NicknameAlert.cs
@@ -9,7 +9,7 @@ using System.Threading.Tasks;
 namespace Floofbot.Modules
 {
     [Summary("Nickname alert configuration commands")]
-    [Discord.Commands.Name("NicknameAlert")]
+    [Name("NicknameAlert")]
     [RequireUserPermission(GuildPermission.Administrator)]
     [Group("nicknamealert")]
     public class NicknameAlert : ModuleBase<SocketCommandContext>

--- a/Floofbot/Modules/RaidProtectionCommands.cs
+++ b/Floofbot/Modules/RaidProtectionCommands.cs
@@ -14,6 +14,7 @@ using System.Threading.Tasks;
 namespace Floofbot.Modules
 {
     [Summary("Raid protection configuration commands")]
+    [Name("Raid Protection Configuration Commands")]
     [RequireUserPermission(GuildPermission.Administrator)]
     [Group("raidconfig")]
     public class RaidProtectionCommands : InteractiveBase

--- a/Floofbot/Modules/TagCommands.cs
+++ b/Floofbot/Modules/TagCommands.cs
@@ -312,6 +312,7 @@ namespace Floofbot.Modules
         }
 
         [Command("")]
+        [Name("tag x")]
         [Summary("Displays a tag")]
         [RequireUserPermission(ChannelPermission.EmbedLinks)]
         [RequireBotPermission(ChannelPermission.AttachFiles)]

--- a/Floofbot/Modules/TagCommands.cs
+++ b/Floofbot/Modules/TagCommands.cs
@@ -14,7 +14,7 @@ using System.Threading.Tasks;
 namespace Floofbot.Modules
 {
     [Summary("Tag commands")]
-    [Discord.Commands.Name("Tag")]
+    [Name("Tag")]
     [Group("tag")]
     [RequireContext(ContextType.Guild)]
     [RequireUserPermission(Discord.GuildPermission.AttachFiles)]

--- a/Floofbot/Modules/UserAssignableRoleCommands.cs
+++ b/Floofbot/Modules/UserAssignableRoleCommands.cs
@@ -14,6 +14,7 @@ namespace Floofbot.Modules
 {
     [RequireContext(ContextType.Guild)]
     [Summary("Add/Remove allowable roles for yourself")]
+    [Name("User Assignable Roles")]
     public class UserAssignableRoleCommands : InteractiveBase
     {
         private FloofDataContext _floofDb;
@@ -146,6 +147,7 @@ namespace Floofbot.Modules
     }
 
     [Summary("Configures the joinable user roles")]
+    [Name("User Assignable Roles Configuration")]
     [RequireUserPermission(GuildPermission.Administrator)]
     [Group("iamconfig")]
     public class UserAssignableRoleAdminCommands : InteractiveBase

--- a/Floofbot/Modules/Utilities.cs
+++ b/Floofbot/Modules/Utilities.cs
@@ -13,7 +13,7 @@ using Floofbot.Configs;
 namespace Floofbot
 {
     [Summary("Utility commands")]
-    [Discord.Commands.Name("Utilities")]
+    [Name("Utilities")]
     public class Utilities : InteractiveBase
     {
         private static readonly Discord.Color EMBED_COLOR = Color.Magenta;


### PR DESCRIPTION
- Users can only see commands that they have met the preconditions to use (eg guild only, administrator)
- Aliases are only shown if they are alternate aliases. Before the command would show eg "help (aliases: help)" as cmd name counts as an alias. Now only alternate aliases are shown