### PR TITLE
Fixed nickname alert regex parsing

### DIFF
--- a/Floofbot/Services/WordFilterService.cs
+++ b/Floofbot/Services/WordFilterService.cs
@@ -34,9 +34,7 @@ namespace Floofbot.Services
 
             foreach (var filteredWord in _filteredWords)
             {
-                Regex r = new Regex($"{filteredWord.Word}",
-                    RegexOptions.IgnoreCase | RegexOptions.Singleline);
-                if (r.IsMatch(messageContent))
+                if (messageContent.ToLower().Contains(filteredWord.Word.ToLower()))
                 {
                     DetectedWords.Add(filteredWord.Word);
                 }
@@ -74,7 +72,7 @@ namespace Floofbot.Services
             {
                 Regex r = new Regex(@$"\b({filteredWord.Word})\b",
                     RegexOptions.IgnoreCase | RegexOptions.Singleline);
-                if (r.IsMatch(messageContent))
+                if (r.IsMatch(Regex.Escape(messageContent)))
                 {
                     return true;
                 }

--- a/Floofbot/Services/WordFilterService.cs
+++ b/Floofbot/Services/WordFilterService.cs
@@ -70,9 +70,9 @@ namespace Floofbot.Services
 
             foreach (var filteredWord in _filteredWords)
             {
-                Regex r = new Regex(@$"\b({filteredWord.Word})\b",
+                Regex r = new Regex(@$"\b({Regex.Escape(filteredWord.Word)}\b",
                     RegexOptions.IgnoreCase | RegexOptions.Singleline);
-                if (r.IsMatch(Regex.Escape(messageContent)))
+                if (r.IsMatch(messageContent))
                 {
                     return true;
                 }


### PR DESCRIPTION
Replaced the nickname alert detection to String.Contains() to prevent filtered words containing regex from being parsed