### PR TITLE
Update UriKind to Relative for birb command

### DIFF
--- a/Floofbot/Modules/Fun.cs
+++ b/Floofbot/Modules/Fun.cs
@@ -169,7 +169,7 @@ namespace Floofbot.Modules
         public async Task RequestBirb()
         {
             string fileUrl = await ApiFetcher.RequestEmbeddableUrlFromApi("https://random.birb.pw/tweet.json", "file");
-            if (!string.IsNullOrEmpty(fileUrl) && Uri.IsWellFormedUriString(fileUrl, UriKind.Absolute))
+            if (!string.IsNullOrEmpty(fileUrl) && Uri.IsWellFormedUriString(fileUrl, UriKind.Relative))
             {
                 fileUrl = "https://random.birb.pw/img/" + fileUrl;
                 await SendAnimalEmbed(":bird:", fileUrl);


### PR DESCRIPTION
The birb command has been spitting out that it is unavailable for quite a while now. Doing a little digging, I found that the file key provided by the API is merely a file, not a full URI. This caused `UriKind.Absolute` to fail the check in `IsWellFormedString`.

This update adjusts to relative so as to not change any logic going on while allowing responses to be provided once again.
![image](https://user-images.githubusercontent.com/9438930/145755150-e6bb6495-e1ea-4bcb-bce4-652bfc63206e.png)

