### PR TITLE
Various bug fixes and feature requests over the last couple years

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -269,6 +269,5 @@ __pycache__/
 
 Floofbot/config.yaml
 /Floofbot/floofData.db
-/Floofbot/config.yaml.sample
 /Floofbot/config.yaml
 /Floofbot/app.config

--- a/Floofbot/Modules/Administration.cs
+++ b/Floofbot/Modules/Administration.cs
@@ -13,6 +13,8 @@ using Microsoft.EntityFrameworkCore;
 using Serilog;
 using System.Drawing.Printing;
 using Discord.Net;
+using System.Security.Cryptography;
+using Microsoft.Extensions.Configuration.UserSecrets;
 
 namespace Floofbot.Modules
 {
@@ -67,6 +69,17 @@ namespace Floofbot.Modules
                 }
             }
 
+            if (badUser.Id == Context.Client.CurrentUser.Id)
+            {
+                await Context.Channel.SendMessageAsync("⚠️ I cannot ban myself.");
+                return;
+            }
+            if (badUser.Id == Context.User.Id)
+            {
+                await Context.Channel.SendMessageAsync("⚠️ For safety reasons, I cannot allow you to ban yourself.");
+                return;
+            }
+
             try
             {
                 //sends message to user
@@ -82,17 +95,81 @@ namespace Floofbot.Modules
                 await Context.Channel.SendMessageAsync("⚠️ | Unable to DM user to notify them of their ban!");
             }
 
-            //bans the user
-            await Context.Guild.AddBanAsync(badUser.Id, 0, $"{Context.User.Username}#{Context.User.Discriminator} -> {reason}");
+            try
+            {
+                //bans the user
+                await Context.Guild.AddBanAsync(badUser.Id, 0, $"{Context.User.Username}#{Context.User.Discriminator} -> {reason}");
 
-            EmbedBuilder modEmbedBuilder = new EmbedBuilder();
-            modEmbedBuilder = new EmbedBuilder();
-            modEmbedBuilder.Title = (":shield: User Banned");
-            modEmbedBuilder.Color = ADMIN_COLOR;
-            modEmbedBuilder.Description = $"{badUser.Username}#{badUser.Discriminator} has been banned from {Context.Guild.Name}";
-            modEmbedBuilder.AddField("User ID", badUser.Id);
-            modEmbedBuilder.AddField("Moderator", $"{Context.User.Username}#{Context.User.Discriminator}");
-            await Context.Channel.SendMessageAsync("", false, modEmbedBuilder.Build());
+                EmbedBuilder modEmbedBuilder = new EmbedBuilder();
+                modEmbedBuilder = new EmbedBuilder();
+                modEmbedBuilder.Title = (":shield: User Banned");
+                modEmbedBuilder.Color = ADMIN_COLOR;
+                modEmbedBuilder.Description = $"{badUser.Username}#{badUser.Discriminator} has been banned from {Context.Guild.Name}";
+                modEmbedBuilder.AddField("User ID", badUser.Id);
+                modEmbedBuilder.AddField("Moderator", $"{Context.User.Username}#{Context.User.Discriminator}");
+                await Context.Channel.SendMessageAsync("", false, modEmbedBuilder.Build());
+            }
+            catch 
+            {
+                await Context.Channel.SendMessageAsync("⚠️ | Unable to ban the user! Check my permissions.");
+            }
+
+        }
+
+        [Command("unban")]
+        [Alias("ub")]
+        [Summary("Unbans a user from the server")]
+        [RequireContext(ContextType.Guild)]
+        [RequireUserPermission(GuildPermission.BanMembers)]
+        public async Task UnYeetUser([Summary("user")] string user)
+        {
+            IUser badUser = resolveUser(user);
+            ulong userId;
+            if (badUser == null)
+            {
+                if (Regex.IsMatch(user, @"\d{16,}"))
+                {
+                    userId = Convert.ToUInt64(Regex.Match(user, @"\d{16,}").Value);
+                }
+                else
+                {
+                    await Context.Channel.SendMessageAsync($"⚠️ Could not resolve user: \"{user}\"");
+                    return;
+                }
+            }
+            else
+            {
+                userId= badUser.Id;
+            }
+
+            if (userId == Context.Client.CurrentUser.Id)
+            {
+                await Context.Channel.SendMessageAsync("⚠️ I cannot unban myself.");
+                return;
+            }
+            if (userId == Context.User.Id)
+            {
+                await Context.Channel.SendMessageAsync("⚠️ For safety reasons, I cannot allow you to unban yourself.");
+                return;
+            }
+            try
+            {
+                await Context.Guild.RemoveBanAsync(userId); // unban user
+
+                EmbedBuilder modEmbedBuilder = new EmbedBuilder();
+                modEmbedBuilder = new EmbedBuilder();
+                modEmbedBuilder.Title = (":shield: User Unbanned");
+                modEmbedBuilder.Color = ADMIN_COLOR;
+                modEmbedBuilder.Description = $"{userId} has been unbanned from {Context.Guild.Name}";
+                modEmbedBuilder.AddField("User ID", userId);
+                modEmbedBuilder.AddField("Moderator", $"{Context.User.Username}#{Context.User.Discriminator}");
+                await Context.Channel.SendMessageAsync("", false, modEmbedBuilder.Build());
+            }
+            catch
+            {
+                await Context.Channel.SendMessageAsync("⚠️ Unable to unban user! Please check that they are actually banned from the server.");
+                return;
+            }
 
         }
 
@@ -136,6 +213,17 @@ namespace Floofbot.Modules
                     await Context.Channel.SendMessageAsync($"⚠️ Could not resolve user: \"{user}\"");
                     return;
                 }
+            }
+
+            if (badUser.Id == Context.Client.CurrentUser.Id)
+            {
+                await Context.Channel.SendMessageAsync("⚠️ I cannot purge and ban myself.");
+                return;
+            }
+            if (badUser.Id == Context.User.Id)
+            {
+                await Context.Channel.SendMessageAsync("⚠️ For safety reasons, I cannot allow you to purge and ban yourself.");
+                return;
             }
 
             try
@@ -265,6 +353,18 @@ namespace Floofbot.Modules
                 await Context.Channel.SendMessageAsync($"⚠️ Could not resolve user: \"{user}\"");
                 return;
             }
+
+            if (badUser.Id == Context.Client.CurrentUser.Id)
+            {
+                await Context.Channel.SendMessageAsync("⚠️ I cannot kick myself.");
+                return;
+            }
+            if (badUser.Id == Context.User.Id)
+            {
+                await Context.Channel.SendMessageAsync("⚠️ For safety reasons, I cannot allow you to kick yourself.");
+                return;
+            }
+
             try
             {
                 //sends message to user
@@ -280,15 +380,23 @@ namespace Floofbot.Modules
                 await Context.Channel.SendMessageAsync("⚠️ | Unable to DM user to notify them of their kick!");
             }
 
-            //kicks users
-            await Context.Guild.GetUser(badUser.Id).KickAsync(reason);
-            EmbedBuilder kickBuilder = new EmbedBuilder();
-            kickBuilder.Title = ("🥾 User Kicked");
-            kickBuilder.Color = ADMIN_COLOR;
-            kickBuilder.Description = $"{badUser.Username}#{badUser.Discriminator} has been kicked from {Context.Guild.Name}";
-            kickBuilder.AddField("User ID", badUser.Id);
-            kickBuilder.AddField("Moderator", $"{Context.User.Username}#{Context.User.Discriminator}");
-            await Context.Channel.SendMessageAsync("", false, kickBuilder.Build());
+            try
+            {
+                //kicks users
+                await Context.Guild.GetUser(badUser.Id).KickAsync(reason);
+                EmbedBuilder kickBuilder = new EmbedBuilder();
+                kickBuilder.Title = ("🥾 User Kicked");
+                kickBuilder.Color = ADMIN_COLOR;
+                kickBuilder.Description = $"{badUser.Username}#{badUser.Discriminator} has been kicked from {Context.Guild.Name}";
+                kickBuilder.AddField("User ID", badUser.Id);
+                kickBuilder.AddField("Moderator", $"{Context.User.Username}#{Context.User.Discriminator}");
+                await Context.Channel.SendMessageAsync("", false, kickBuilder.Build());
+            }
+            catch 
+            {
+                await Context.Channel.SendMessageAsync("⚠️ | Unable to kick user! Check my permissions.");
+                return;
+            }
         }
 
         [Command("silentkick")]
@@ -307,15 +415,33 @@ namespace Floofbot.Modules
                 return;
             }
 
-            //kicks users
-            await Context.Guild.GetUser(badUser.Id).KickAsync(reason);
-            EmbedBuilder kickBuilder = new EmbedBuilder();
-            kickBuilder.Title = ("🥾 User Silently Kicked");
-            kickBuilder.Color = ADMIN_COLOR;
-            kickBuilder.Description = $"{badUser.Username}#{badUser.Discriminator} has been silently kicked from {Context.Guild.Name}";
-            kickBuilder.AddField("User ID", badUser.Id);
-            kickBuilder.AddField("Moderator", $"{Context.User.Username}#{Context.User.Discriminator}");
-            await Context.Channel.SendMessageAsync("", false, kickBuilder.Build());
+            if (badUser.Id == Context.Client.CurrentUser.Id)
+            {
+                await Context.Channel.SendMessageAsync("⚠️ I cannot kick myself.");
+                return;
+            }
+            if (badUser.Id == Context.User.Id)
+            {
+                await Context.Channel.SendMessageAsync("⚠️ For safety reasons, I cannot allow you to kick yourself.");
+                return;
+            }
+            try
+            {
+                //kicks users
+                await Context.Guild.GetUser(badUser.Id).KickAsync(reason);
+                EmbedBuilder kickBuilder = new EmbedBuilder();
+                kickBuilder.Title = ("🥾 User Silently Kicked");
+                kickBuilder.Color = ADMIN_COLOR;
+                kickBuilder.Description = $"{badUser.Username}#{badUser.Discriminator} has been silently kicked from {Context.Guild.Name}";
+                kickBuilder.AddField("User ID", badUser.Id);
+                kickBuilder.AddField("Moderator", $"{Context.User.Username}#{Context.User.Discriminator}");
+                await Context.Channel.SendMessageAsync("", false, kickBuilder.Build());
+            }
+            catch
+            {
+                await Context.Channel.SendMessageAsync("⚠️ | Unable to kick user! Check my permissions.");
+                return;
+            }
         }
 
         [Command("warn")]
@@ -358,6 +484,16 @@ namespace Floofbot.Modules
             }
             else
             {
+                if (badUser.Id == Context.Client.CurrentUser.Id)
+                {
+                    await Context.Channel.SendMessageAsync("⚠️ I cannot warn myself.");
+                    return;
+                }
+                if (badUser.Id == Context.User.Id)
+                {
+                    await Context.Channel.SendMessageAsync("⚠️ For safety reasons, I cannot allow you to warn yourself.");
+                    return;
+                }
                 uid = badUser.Id;
             }
 
@@ -395,6 +531,8 @@ namespace Floofbot.Modules
             builder = new EmbedBuilder();
             builder.Title = (":shield: User Warned");
             builder.Color = ADMIN_COLOR;
+            string badUserIdentifier = (badUser != null) ? $"{badUser.Username}#{badUser.Discriminator}" : $"{uid}";
+            builder.Description = $"Warning added for {badUserIdentifier} with reason {reason}";
             builder.AddField("User ID", uid);
             builder.AddField("Moderator", $"{Context.User.Username}#{Context.User.Discriminator}");
 
@@ -441,6 +579,16 @@ namespace Floofbot.Modules
             }
             else
             {
+                if (badUser.Id == Context.Client.CurrentUser.Id)
+                {
+                    await Context.Channel.SendMessageAsync("⚠️ I cannot add usernotes for myself.");
+                    return;
+                }
+                if (badUser.Id == Context.User.Id)
+                {
+                    await Context.Channel.SendMessageAsync("⚠️ For safety reasons, I cannot allow you to add usernotes to yourself.");
+                    return;
+                }
                 uid = badUser.Id;
             }
 
@@ -458,6 +606,8 @@ namespace Floofbot.Modules
             builder = new EmbedBuilder();
             builder.Title = (":pencil: User Note Added");
             builder.Color = ADMIN_COLOR;
+            string badUserIdentifier = (badUser != null) ? $"{badUser.Username}#{badUser.Discriminator}" : $"{uid}";
+            builder.Description = $"Usernote added for {badUserIdentifier} with reason {reason}";
             builder.AddField("User ID", uid);
             builder.AddField("Moderator", $"{Context.User.Username}#{Context.User.Discriminator}");
 
@@ -480,7 +630,7 @@ namespace Floofbot.Modules
                 {
                     userId = Regex.Match(user, @"\d{16,}").Value;
                 }
-                else 
+                else
                 {
                     await Context.Channel.SendMessageAsync("⚠️ Cannot find user");
                     return;
@@ -488,9 +638,18 @@ namespace Floofbot.Modules
             }
             else
             {
+                if (badUser.Id == Context.Client.CurrentUser.Id)
+                {
+                    await Context.Channel.SendMessageAsync("⚠️ I cannot purge my own messages.");
+                    return;
+                }
+                if (badUser.Id == Context.User.Id)
+                {
+                    await Context.Channel.SendMessageAsync("⚠️ For safety reasons, I cannot purge your own messages.");
+                    return;
+                }
                 userId = badUser.Id.ToString();
             }
-
             // retrieve user messages from ALL channels
             foreach (ISocketMessageChannel channel in Context.Guild.TextChannels)
             {
@@ -501,8 +660,11 @@ namespace Floofbot.Modules
                     {
                         if (message.Author.Id.ToString() == userId)
                         {
-                            await channel.DeleteMessageAsync(message);
-                            await Task.Delay(100); // helps reduce the risk of getting rate limited by the API
+                            if (message != null)
+                            {
+                                await channel.DeleteMessageAsync(message);
+                                await Task.Delay(100); // helps reduce the risk of getting rate limited by the API
+                            }
                         }
                     }
                 }
@@ -511,6 +673,8 @@ namespace Floofbot.Modules
             EmbedBuilder builder = new EmbedBuilder();
             builder.Title = (":shield: Messages Purged");
             builder.Color = ADMIN_COLOR;
+            string badUserIdentifier = (badUser != null) ? $"{badUser.Username}#{badUser.Discriminator}" : $"{userId}";
+            builder.Description = $"{badUser.Username}#{badUser.Discriminator}'s messages were purged";
             builder.AddField("User ID", badUser.Id);
             builder.AddField("Moderator", $"{Context.User.Username}#{Context.User.Discriminator}");
 
@@ -537,7 +701,7 @@ namespace Floofbot.Modules
             }
             else // a mod
             {
-                if (selfUser.GuildPermissions.KickMembers) // want to view their own warnlog 
+                if (selfUser.GuildPermissions.KickMembers) // moderator wants to view a warnlog
                 {
                     IUser badUser = resolveUser(user);
                     if (badUser == null)
@@ -549,7 +713,14 @@ namespace Floofbot.Modules
                             return;
                         }
                     else
+                    {
+                        if (badUser.Id == Context.Client.CurrentUser.Id)
+                        {
+                            await Context.Channel.SendMessageAsync("⚠️ You cannot view my warnlog.");
+                            return;
+                        }
                         embed = GetWarnings(badUser.Id, false);
+                    }
                     if (embed == null)
                     {
                             return;
@@ -584,6 +755,20 @@ namespace Floofbot.Modules
             await UpdateForgivenStatus("unforgiven", type, badUser);
         }
 
+        [Command("userid")]
+        [Summary("Displays the ID of the specified user. If no parameters are given, displays the user's own ID")]
+        [RequireContext(ContextType.Guild)]
+        [RequireBotPermission(GuildPermission.KickMembers)]
+        public async Task UserId(IGuildUser usr = null)
+        {
+            var user = usr ?? Context.User as IGuildUser;
+
+            if (user == null)
+                return;
+
+            await Context.Channel.SendMessageAsync(user.Id.ToString());
+        }
+
         [Command("mute")]
         [Summary("Applies a mute role to a user")]
         [RequireContext(ContextType.Guild)]
@@ -593,6 +778,17 @@ namespace Floofbot.Modules
             IUser badUser = resolveUser(user);
             if (badUser == null) {
                 await Context.Channel.SendMessageAsync($"⚠️ Could not find user \"{user}\"");
+                return;
+            }
+
+            if (badUser.Id == Context.Client.CurrentUser.Id)
+            {
+                await Context.Channel.SendMessageAsync("⚠️ I cannot mute myself.");
+                return;
+            }
+            if (badUser.Id == Context.User.Id)
+            {
+                await Context.Channel.SendMessageAsync("⚠️ For safety reasons, I cannot allow you to mute yourself.");
                 return;
             }
 
@@ -745,6 +941,17 @@ namespace Floofbot.Modules
             IUser badUser = resolveUser(user);
             if (badUser == null) {
                 await Context.Channel.SendMessageAsync($"⚠️ Could not find user \"{user}\"");
+                return;
+            }
+
+            if (badUser.Id == Context.Client.CurrentUser.Id)
+            {
+                await Context.Channel.SendMessageAsync("⚠️ I cannot unmute myself.");
+                return;
+            }
+            if (badUser.Id == Context.User.Id)
+            {
+                await Context.Channel.SendMessageAsync("⚠️ For safety reasons, I cannot allow you to unmute yourself.");
                 return;
             }
 
@@ -1035,27 +1242,15 @@ namespace Floofbot.Modules
                     .Where(u => u.UserId == uid && u.GuildId == Context.Guild.Id)
                     .OrderByDescending(x => x.DateAdded).Take(10);
             }
-
+            string badUserIdentifier = (badUser != null) ? $"{badUser.Username}#{badUser.Discriminator}" : $"{uid}";
             if (!isOwnLog) // mod viewing someones history
             {
-                if (badUser == null) // client cant get user - no mutual servers?
-                {
                     if (formalWarnings.Count() == 0 && userNotes.Count() == 0)
                     {
-                        string message = $"{uid} is a good noodle. They have no warnings or user notes!";
+                        string message = $"{badUserIdentifier} is a good noodle. They have no warnings or user notes!";
                         var embed = CreateDescriptionEmbed(message);
                         return embed;
                     }
-                }
-                else
-                {
-                    if (formalWarnings.Count() == 0 && userNotes.Count() == 0)
-                    {
-                        string message = $"{badUser.Username}#{badUser.Discriminator} is a good noodle. They have no warnings or user notes!";
-                        var embed = CreateDescriptionEmbed(message);
-                        return embed;
-                    }
-                }
             }
             else // own users history
             {
@@ -1072,10 +1267,8 @@ namespace Floofbot.Modules
             int warningCount = 0;
             int userNoteCount = 0;
 
-            if (badUser == null && !isOwnLog) // no user, just id in database
-                builder.WithTitle($"Warnings for {uid}");
-            else if (badUser != null && !isOwnLog)
-                builder.WithTitle($"Warnings for {badUser.Username}#{badUser.Discriminator}");
+            if (!isOwnLog) // no user, just id in database
+                builder.WithTitle($"Warnings for {badUserIdentifier}");
             else
                 builder.WithTitle($"Your Warnings");
 

--- a/Floofbot/Modules/Administration.cs
+++ b/Floofbot/Modules/Administration.cs
@@ -99,21 +99,20 @@ namespace Floofbot.Modules
             {
                 //bans the user
                 await Context.Guild.AddBanAsync(badUser.Id, 0, $"{Context.User.Username}#{Context.User.Discriminator} -> {reason}");
-
-                EmbedBuilder modEmbedBuilder = new EmbedBuilder();
-                modEmbedBuilder = new EmbedBuilder();
-                modEmbedBuilder.Title = (":shield: User Banned");
-                modEmbedBuilder.Color = ADMIN_COLOR;
-                modEmbedBuilder.Description = $"{badUser.Username}#{badUser.Discriminator} has been banned from {Context.Guild.Name}";
-                modEmbedBuilder.AddField("User ID", badUser.Id);
-                modEmbedBuilder.AddField("Moderator", $"{Context.User.Username}#{Context.User.Discriminator}");
-                await Context.Channel.SendMessageAsync("", false, modEmbedBuilder.Build());
             }
-            catch 
+            catch (Exception ex)
             {
-                await Context.Channel.SendMessageAsync("⚠️ | Unable to ban the user! Check my permissions.");
+                await Context.Channel.SendMessageAsync("Command unable to be performed sucessfully: " + ex.ToString());
+                return;
             }
-
+            EmbedBuilder modEmbedBuilder = new EmbedBuilder();
+            modEmbedBuilder = new EmbedBuilder();
+            modEmbedBuilder.Title = (":shield: User Banned");
+            modEmbedBuilder.Color = ADMIN_COLOR;
+            modEmbedBuilder.Description = $"{badUser.Username}#{badUser.Discriminator} has been banned from {Context.Guild.Name}";
+            modEmbedBuilder.AddField("User ID", badUser.Id);
+            modEmbedBuilder.AddField("Moderator", $"{Context.User.Username}#{Context.User.Discriminator}");
+            await Context.Channel.SendMessageAsync("", false, modEmbedBuilder.Build());
         }
 
         [Command("unban")]
@@ -155,22 +154,20 @@ namespace Floofbot.Modules
             try
             {
                 await Context.Guild.RemoveBanAsync(userId); // unban user
-
-                EmbedBuilder modEmbedBuilder = new EmbedBuilder();
-                modEmbedBuilder = new EmbedBuilder();
-                modEmbedBuilder.Title = (":shield: User Unbanned");
-                modEmbedBuilder.Color = ADMIN_COLOR;
-                modEmbedBuilder.Description = $"{userId} has been unbanned from {Context.Guild.Name}";
-                modEmbedBuilder.AddField("User ID", userId);
-                modEmbedBuilder.AddField("Moderator", $"{Context.User.Username}#{Context.User.Discriminator}");
-                await Context.Channel.SendMessageAsync("", false, modEmbedBuilder.Build());
             }
-            catch
+            catch (Exception ex)
             {
-                await Context.Channel.SendMessageAsync("⚠️ Unable to unban user! Please check that they are actually banned from the server.");
+                await Context.Channel.SendMessageAsync("Command unable to be performed sucessfully: " + ex.ToString());
                 return;
             }
-
+            EmbedBuilder modEmbedBuilder = new EmbedBuilder();
+            modEmbedBuilder = new EmbedBuilder();
+            modEmbedBuilder.Title = (":shield: User Unbanned");
+            modEmbedBuilder.Color = ADMIN_COLOR;
+            modEmbedBuilder.Description = $"{userId} has been unbanned from {Context.Guild.Name}";
+            modEmbedBuilder.AddField("User ID", userId);
+            modEmbedBuilder.AddField("Moderator", $"{Context.User.Username}#{Context.User.Discriminator}");
+            await Context.Channel.SendMessageAsync("", false, modEmbedBuilder.Build());
         }
 
         [Command("pruneban")]
@@ -243,21 +240,20 @@ namespace Floofbot.Modules
             {
                 //bans the user
                 await Context.Guild.AddBanAsync(badUser.Id, 7, $"{Context.User.Username}#{Context.User.Discriminator} -> {reason}"); // default 7 days prune
-
-                EmbedBuilder modEmbedBuilder = new EmbedBuilder();
-                modEmbedBuilder = new EmbedBuilder();
-                modEmbedBuilder.Title = (":shield: User Banned");
-                modEmbedBuilder.Color = ADMIN_COLOR;
-                modEmbedBuilder.Description = $"{badUser.Username}#{badUser.Discriminator} has been banned from {Context.Guild.Name}";
-                modEmbedBuilder.AddField("User ID", badUser.Id);
-                modEmbedBuilder.AddField("Moderator", $"{Context.User.Username}#{Context.User.Discriminator}");
-                await Context.Channel.SendMessageAsync("", false, modEmbedBuilder.Build());
             }
-            catch
+            catch (Exception ex)
             {
-                await Context.Channel.SendMessageAsync("⚠️ | Sorry, I was unable to ban that user!");
+                await Context.Channel.SendMessageAsync("Command unable to be performed sucessfully: " + ex.ToString());
                 return;
             }
+            EmbedBuilder modEmbedBuilder = new EmbedBuilder();
+            modEmbedBuilder = new EmbedBuilder();
+            modEmbedBuilder.Title = (":shield: User Banned");
+            modEmbedBuilder.Color = ADMIN_COLOR;
+            modEmbedBuilder.Description = $"{badUser.Username}#{badUser.Discriminator} has been banned from {Context.Guild.Name}";
+            modEmbedBuilder.AddField("User ID", badUser.Id);
+            modEmbedBuilder.AddField("Moderator", $"{Context.User.Username}#{Context.User.Discriminator}");
+            await Context.Channel.SendMessageAsync("", false, modEmbedBuilder.Build());
         }
 
         [Command("viewautobans")]
@@ -435,19 +431,19 @@ namespace Floofbot.Modules
             {
                 //kicks users
                 await Context.Guild.GetUser(badUser.Id).KickAsync(reason);
-                EmbedBuilder kickBuilder = new EmbedBuilder();
+            }
+            catch (Exception ex)
+            {
+                await Context.Channel.SendMessageAsync("Command unable to be performed sucessfully: " + ex.ToString());
+                return;
+            }
+            EmbedBuilder kickBuilder = new EmbedBuilder();
                 kickBuilder.Title = ("🥾 User Silently Kicked");
                 kickBuilder.Color = ADMIN_COLOR;
                 kickBuilder.Description = $"{badUser.Username}#{badUser.Discriminator} has been silently kicked from {Context.Guild.Name}";
                 kickBuilder.AddField("User ID", badUser.Id);
                 kickBuilder.AddField("Moderator", $"{Context.User.Username}#{Context.User.Discriminator}");
                 await Context.Channel.SendMessageAsync("", false, kickBuilder.Build());
-            }
-            catch
-            {
-                await Context.Channel.SendMessageAsync("⚠️ | Unable to kick user! Check my permissions.");
-                return;
-            }
         }
 
         [Command("warn")]
@@ -1210,7 +1206,7 @@ namespace Floofbot.Modules
             }
             catch (Exception ex)
             {
-                await Context.Channel.SendMessageAsync(ex.ToString());
+                await Context.Channel.SendMessageAsync("Command unable to be performed sucessfully: " + ex.ToString());
             }
         }
         private async Task SetWarningForgivenStatus(Warning w, bool status, ulong forgivenBy)

--- a/Floofbot/Modules/Administration.cs
+++ b/Floofbot/Modules/Administration.cs
@@ -180,7 +180,6 @@ namespace Floofbot.Modules
         [RequireUserPermission(GuildPermission.BanMembers)]
         public async Task pruneBanUser(
             [Summary("user")] string user,
-            [Summary("Number Of Days To Prune")] int pruneDays = 0,
             [Summary("reason")][Remainder] string reason = "No Reason Provided")
         {
             IUser badUser = resolveUser(user);
@@ -240,18 +239,25 @@ namespace Floofbot.Modules
             {
                 await Context.Channel.SendMessageAsync("⚠️ | Unable to DM user to notify them of their ban!");
             }
+            try
+            {
+                //bans the user
+                await Context.Guild.AddBanAsync(badUser.Id, 7, $"{Context.User.Username}#{Context.User.Discriminator} -> {reason}"); // default 7 days prune
 
-            //bans the user
-            await Context.Guild.AddBanAsync(badUser.Id, pruneDays, $"{Context.User.Username}#{Context.User.Discriminator} -> {reason}");
-
-            EmbedBuilder modEmbedBuilder = new EmbedBuilder();
-            modEmbedBuilder = new EmbedBuilder();
-            modEmbedBuilder.Title = (":shield: User Banned");
-            modEmbedBuilder.Color = ADMIN_COLOR;
-            modEmbedBuilder.Description = $"{badUser.Username}#{badUser.Discriminator} has been banned from {Context.Guild.Name}";
-            modEmbedBuilder.AddField("User ID", badUser.Id);
-            modEmbedBuilder.AddField("Moderator", $"{Context.User.Username}#{Context.User.Discriminator}");
-            await Context.Channel.SendMessageAsync("", false, modEmbedBuilder.Build());
+                EmbedBuilder modEmbedBuilder = new EmbedBuilder();
+                modEmbedBuilder = new EmbedBuilder();
+                modEmbedBuilder.Title = (":shield: User Banned");
+                modEmbedBuilder.Color = ADMIN_COLOR;
+                modEmbedBuilder.Description = $"{badUser.Username}#{badUser.Discriminator} has been banned from {Context.Guild.Name}";
+                modEmbedBuilder.AddField("User ID", badUser.Id);
+                modEmbedBuilder.AddField("Moderator", $"{Context.User.Username}#{Context.User.Discriminator}");
+                await Context.Channel.SendMessageAsync("", false, modEmbedBuilder.Build());
+            }
+            catch
+            {
+                await Context.Channel.SendMessageAsync("⚠️ | Sorry, I was unable to ban that user!");
+                return;
+            }
         }
 
         [Command("viewautobans")]

--- a/Floofbot/Modules/Fun.cs
+++ b/Floofbot/Modules/Fun.cs
@@ -181,7 +181,7 @@ namespace Floofbot.Modules
             catch (Exception ex)
             {
                 await Context.Channel.SendMessageAsync("The dog command is currently unavailable.");
-                Log.Error(ex.ToString())
+                Log.Error(ex.ToString());
                 return;
             }
         }

--- a/Floofbot/Modules/Fun.cs
+++ b/Floofbot/Modules/Fun.cs
@@ -123,14 +123,22 @@ namespace Floofbot.Modules
         [Summary("Responds with a random cat")]
         public async Task RequestCat()
         {
-            string fileUrl = await ApiFetcher.RequestEmbeddableUrlFromApi("https://aws.random.cat/meow", "file");
-            if (!string.IsNullOrEmpty(fileUrl) && Uri.IsWellFormedUriString(fileUrl, UriKind.Absolute))
+            try
             {
-                await SendAnimalEmbed(":cat:", fileUrl);
+                string fileUrl = await ApiFetcher.RequestEmbeddableUrlFromApi("https://aws.random.cat/meow", "file");
+                if (!string.IsNullOrEmpty(fileUrl) && Uri.IsWellFormedUriString(fileUrl, UriKind.Absolute))
+                {
+                    await SendAnimalEmbed(":cat:", fileUrl);
+                }
+                else
+                {
+                    await Context.Channel.SendMessageAsync("The cat command is currently unavailable.");
+                }
             }
-            else
+            catch
             {
                 await Context.Channel.SendMessageAsync("The cat command is currently unavailable.");
+                return;
             }
         }
 
@@ -138,14 +146,22 @@ namespace Floofbot.Modules
         [Summary("Responds with a random dog")]
         public async Task RequestDog()
         {
-            string fileUrl = await ApiFetcher.RequestEmbeddableUrlFromApi("https://random.dog/woof.json", "url");
-            if (!string.IsNullOrEmpty(fileUrl) && Uri.IsWellFormedUriString(fileUrl, UriKind.Absolute))
+            try
             {
-                await SendAnimalEmbed(":dog:", fileUrl);
+                string fileUrl = await ApiFetcher.RequestEmbeddableUrlFromApi("https://random.dog/woof.json", "url");
+                if (!string.IsNullOrEmpty(fileUrl) && Uri.IsWellFormedUriString(fileUrl, UriKind.Absolute))
+                {
+                    await SendAnimalEmbed(":dog:", fileUrl);
+                }
+                else
+                {
+                    await Context.Channel.SendMessageAsync("The dog command is currently unavailable.");
+                }
             }
-            else
+            catch
             {
                 await Context.Channel.SendMessageAsync("The dog command is currently unavailable.");
+                return;
             }
         }
 
@@ -153,14 +169,22 @@ namespace Floofbot.Modules
         [Summary("Responds with a random fox")]
         public async Task RequestFox()
         {
-            string fileUrl = await ApiFetcher.RequestEmbeddableUrlFromApi("https://wohlsoft.ru/images/foxybot/randomfox.php", "file");
-            if (!string.IsNullOrEmpty(fileUrl) && Uri.IsWellFormedUriString(fileUrl, UriKind.Absolute))
+            try
             {
-                await SendAnimalEmbed(":fox:", fileUrl);
+                string fileUrl = await ApiFetcher.RequestEmbeddableUrlFromApi("https://wohlsoft.ru/images/foxybot/randomfox.php", "file");
+                if (!string.IsNullOrEmpty(fileUrl) && Uri.IsWellFormedUriString(fileUrl, UriKind.Absolute))
+                {
+                    await SendAnimalEmbed(":fox:", fileUrl);
+                }
+                else
+                {
+                    await Context.Channel.SendMessageAsync("The fox command is currently unavailable.");
+                }
             }
-            else
+            catch
             {
                 await Context.Channel.SendMessageAsync("The fox command is currently unavailable.");
+                return;
             }
         }
 
@@ -168,15 +192,23 @@ namespace Floofbot.Modules
         [Summary("Responds with a random birb")]
         public async Task RequestBirb()
         {
-            string fileUrl = await ApiFetcher.RequestEmbeddableUrlFromApi("https://random.birb.pw/tweet.json", "file");
-            if (!string.IsNullOrEmpty(fileUrl) && Uri.IsWellFormedUriString(fileUrl, UriKind.Relative))
+            try
             {
-                fileUrl = "https://random.birb.pw/img/" + fileUrl;
-                await SendAnimalEmbed(":bird:", fileUrl);
+                string fileUrl = await ApiFetcher.RequestEmbeddableUrlFromApi("https://random.birb.pw/tweet.json", "file");
+                if (!string.IsNullOrEmpty(fileUrl) && Uri.IsWellFormedUriString(fileUrl, UriKind.Relative))
+                {
+                    fileUrl = "https://random.birb.pw/img/" + fileUrl;
+                    await SendAnimalEmbed(":bird:", fileUrl);
+                }
+                else
+                {
+                    await Context.Channel.SendMessageAsync("The birb command is currently unavailable.");
+                }
             }
-            else
+            catch
             {
                 await Context.Channel.SendMessageAsync("The birb command is currently unavailable.");
+                return;
             }
         }
 

--- a/Floofbot/Modules/Fun.cs
+++ b/Floofbot/Modules/Fun.cs
@@ -94,14 +94,23 @@ namespace Floofbot.Modules
         [Summary("Responds with a random cat fact")]
         public async Task RequestCatFact()
         {
-            string fact = await ApiFetcher.RequestStringFromApi("https://catfact.ninja/fact", "fact");
-            if (!string.IsNullOrEmpty(fact))
+            try
             {
-                await Context.Channel.SendMessageAsync(fact);
+                string fact = await ApiFetcher.RequestStringFromApi("https://catfact.ninja/fact", "fact");
+                if (!string.IsNullOrEmpty(fact))
+                {
+                    await Context.Channel.SendMessageAsync(fact);
+                }
+                else
+                {
+                    await Context.Channel.SendMessageAsync("The catfact command is currently unavailable.");
+                }
             }
-            else
+            catch (Exception ex)
             {
                 await Context.Channel.SendMessageAsync("The catfact command is currently unavailable.");
+                Log.Error(ex.ToString());
+                return;
             }
         }
 
@@ -109,14 +118,23 @@ namespace Floofbot.Modules
         [Summary("Responds with a random fox fact")]
         public async Task RequestFoxFact()
         {
-            string fact = await ApiFetcher.RequestStringFromApi("https://some-random-api.ml/facts/fox", "fact");
-            if (!string.IsNullOrEmpty(fact))
+            try
             {
-                await Context.Channel.SendMessageAsync(fact);
+                string fact = await ApiFetcher.RequestStringFromApi("https://some-random-api.ml/facts/fox", "fact");
+                if (!string.IsNullOrEmpty(fact))
+                {
+                    await Context.Channel.SendMessageAsync(fact);
+                }
+                else
+                {
+                    await Context.Channel.SendMessageAsync("The foxfact command is currently unavailable.");
+                }
             }
-            else
+            catch (Exception ex)
             {
                 await Context.Channel.SendMessageAsync("The foxfact command is currently unavailable.");
+                Log.Error(ex.ToString());
+                return;
             }
         }
 
@@ -163,7 +181,7 @@ namespace Floofbot.Modules
             catch (Exception ex)
             {
                 await Context.Channel.SendMessageAsync("The dog command is currently unavailable.");
-                Log.Error(ex.ToString());
+                Log.Error(ex.ToString())
                 return;
             }
         }
@@ -184,9 +202,10 @@ namespace Floofbot.Modules
                     await Context.Channel.SendMessageAsync("The fox command is currently unavailable.");
                 }
             }
-            catch
+            catch (Exception ex)
             {
                 await Context.Channel.SendMessageAsync("The fox command is currently unavailable.");
+                Log.Error(ex.ToString());
                 return;
             }
         }
@@ -208,9 +227,10 @@ namespace Floofbot.Modules
                     await Context.Channel.SendMessageAsync("The birb command is currently unavailable.");
                 }
             }
-            catch
+            catch (Exception ex)
             {
                 await Context.Channel.SendMessageAsync("The birb command is currently unavailable.");
+                Log.Error(ex.ToString());
                 return;
             }
         }

--- a/Floofbot/Modules/Fun.cs
+++ b/Floofbot/Modules/Fun.cs
@@ -1,6 +1,7 @@
 ﻿using Discord;
 using Discord.Commands;
 using Floofbot.Modules.Helpers;
+using Serilog;
 using System;
 using System.Linq;
 using System.Text.Json;
@@ -135,9 +136,10 @@ namespace Floofbot.Modules
                     await Context.Channel.SendMessageAsync("The cat command is currently unavailable.");
                 }
             }
-            catch
+            catch (Exception ex)
             {
-                await Context.Channel.SendMessageAsync("The cat command is currently unavailable.");
+                await Context.Channel.SendMessageAsync("The cat command is currently unavailable");
+                Log.Error(ex.ToString());
                 return;
             }
         }
@@ -158,9 +160,10 @@ namespace Floofbot.Modules
                     await Context.Channel.SendMessageAsync("The dog command is currently unavailable.");
                 }
             }
-            catch
+            catch (Exception ex)
             {
                 await Context.Channel.SendMessageAsync("The dog command is currently unavailable.");
+                Log.Error(ex.ToString());
                 return;
             }
         }

--- a/Floofbot/Modules/Help.cs
+++ b/Floofbot/Modules/Help.cs
@@ -66,11 +66,13 @@ namespace Floofbot.Modules
                 }
                 if (fields.Count > 0) // don't show empty pages
                 {
+                    string strCmdAliases = string.Join(", ", module.Aliases.ToList());
+                    string cmdAliases = (strCmdAliases != "") ? $"Command Usage: {strCmdAliases}\n\n" : "";
                     pages.Add(new PaginatedMessage.Page
                     {
-                        Author = new EmbedAuthorBuilder { Name = module.Name },
+                        Author = new EmbedAuthorBuilder { Name = module.Name},
                         Fields = new List<EmbedFieldBuilder>(fields),
-                        Description = module.Summary ?? "No module description available"
+                        Description = cmdAliases + (module.Summary ?? $"No module description available")
                     });
                     fields.Clear();
                 }
@@ -113,10 +115,10 @@ namespace Floofbot.Modules
                     }
                     pages.Add(new PaginatedMessage.Page
                     {
-                        Author = new EmbedAuthorBuilder { Name = cmd.Name },
+                        Title = "Command Aliases: " + String.Join(", ", cmd.Aliases.ToList()),
                         Fields = new List<EmbedFieldBuilder>(fields),
                         Description = cmd.Summary ?? "No command description available"
-                    });
+                    }); 
                     fields.Clear();
                 }
             }

--- a/Floofbot/Modules/Help.cs
+++ b/Floofbot/Modules/Help.cs
@@ -118,7 +118,7 @@ namespace Floofbot.Modules
                         Title = "Command Aliases: " + String.Join(", ", cmd.Aliases.ToList()),
                         Fields = new List<EmbedFieldBuilder>(fields),
                         Description = cmd.Summary ?? "No command description available"
-                    }); 
+                    });
                     fields.Clear();
                 }
             }

--- a/Floofbot/Services/EventHandlerService.cs
+++ b/Floofbot/Services/EventHandlerService.cs
@@ -54,6 +54,8 @@ namespace Floofbot.Services
             _client.MessageReceived += OnMessage;
             _client.MessageReceived += RulesGate; // rfurry rules gate
             _client.ReactionAdded += _nicknameAlertService.OnReactionAdded;
+            _client.ThreadCreated += NewThread;
+            _client.ThreadUpdated += UpdatedThread;
 
             // a list of announcement channels for auto publishing
             announcementChannels = BotConfigFactory.Config.AnnouncementChannels;
@@ -145,6 +147,21 @@ namespace Floofbot.Services
                 var user = (IGuildUser)msg.Author;
                 await user.AddRoleAsync(user.Guild.GetRole(readRulesRoleId));
                 await userMsg.DeleteAsync();
+            }
+        }
+        public async Task NewThread(SocketThreadChannel thread)
+        {
+            await thread.JoinAsync();
+            return;
+        }
+        public async Task UpdatedThread(Cacheable<SocketThreadChannel, ulong> channel, SocketThreadChannel thread)
+        {
+            if (thread != null)
+            {
+                if (thread.HasJoined != true)
+                {
+                    await thread.JoinAsync();
+                }
             }
         }
         public Task OnMessage(SocketMessage msg)

--- a/Floofbot/Services/RaidProtectionService.cs
+++ b/Floofbot/Services/RaidProtectionService.cs
@@ -155,7 +155,7 @@ namespace Floofbot.Services
             // we run an async task to remove their point after the specified duration
             UserPunishmentTimeout(guildId, msg.Author.Id);
 
-            SendMessageAndDelete($"{msg.Author.Mention} There was a filtered word in that message. Please be mindful of your language!", msg.Channel);
+            SendMessageAndDelete($"{msg.Author.Mention} I detected a filtered word in that message and have automatically deleted it.", msg.Channel);
 
             Log.Information("User ID " + msg.Author.Id + " triggered the word filter.");
 

--- a/Floofbot/Services/RaidProtectionService.cs
+++ b/Floofbot/Services/RaidProtectionService.cs
@@ -302,6 +302,16 @@ namespace Floofbot.Services
             }
             return false;
         }
+        private bool CheckFALinks(SocketMessage msg, ulong guildId) // filter out if not sfw domain but no muting
+        {
+            var regex = "(?<!sfw\\.)(furaffinity.net)";
+            if (Regex.IsMatch(msg.Content, regex))
+            {
+                msg.Channel.SendMessageAsync(msg.Author.Mention + " please use the sfw furaffinity domain (sfw.furaffinity.net) for all FA URLs!");
+                return true;
+            }
+            return false;
+        }
         private bool CheckEmojiSpam(SocketMessage msg, ulong guildId)
         {
             // check for repeated custom and normal emojis. 
@@ -422,9 +432,13 @@ namespace Floofbot.Services
             bool userSpammedInviteLink = CheckInviteLinks(userMsg, guild.Id);
             // check for spammed emojis
             bool userSpammedEmojis = CheckEmojiSpam(userMsg, guild.Id);
+            // check for FA links without sfw domain
+            bool userWrongFALink = CheckFALinks(userMsg, guild.Id);
 
             if (spammedMentions)
                 return false; // user already banned
+            if (userWrongFALink)
+                return true; // user already informed to use sfw domain so finished
             if (filteredWord || userSpammedMessages || userSpammedLetters || userSpammedInviteLink || userSpammedEmojis)
             {
                 if (userPunishmentCount[guild.Id].ContainsKey(userMsg.Author.Id))


### PR DESCRIPTION
Addresses various bug fixes noted by users and moderators:

CHANGES:
- Ensure a username/id is always resolved for all admin commands
- Add protection against a moderator performing actions on themselves or the bot
- Added a check for pruning messages that the message is not a null object (incase this message is deleted whilst the bot is purging or exists in cache but not in discord)
- Updated filter message warn to be less aggressive
- Added try/catch to catch errors where response is not as expected for parsing or permissions are missing
- Added unban command
- Add command aliases to the help page
- Added a moderation command to fetch a user id
- Added event handlers to make the bot join all threads that are updated or created (avoided running a service to check the bot is in all threads to avoid API rate limiting)
- Enforce SFW FA links
- Set the number of days to prune for pb command to 7

(PR https://github.com/bealsbe/Floofbot/pull/170 needs to be accepted first before this PR)